### PR TITLE
🔧 eslintignore파일 추가 - #1

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,2 @@
+vite.config*
+.prettierrc*


### PR DESCRIPTION
### 📌 관련 이슈
이슈번호 #1 

### ✨개발 내용
- .eslintignore 파일 생성 (역할: eslint 적용 제외 파일)
- 제외 대상으로 vite 설정 파일, prettier 파일 추가
   (prettier는 eslint 대상일 필요가 없다가 판단되어 추가) 

### 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
- 오류: eslint에서 vite 설정파일에 다음과 같은 문구로 오류발생
  `'vite' should be listed in the project's dependencies, not devDependencies.` 
  <img width="782" alt="image" src="https://user-images.githubusercontent.com/19286161/218757938-333905a1-d271-4c86-b250-0e7d7b98ffa4.png">


- 원인: vite 패키지의 경우 개발 / 빌드에 사용되기 떄문에 devDendencies에만 리스트가 존재하여 eslint가 오류로 판단
  <img width="357" alt="image" src="https://user-images.githubusercontent.com/19286161/218757406-9aec1105-a6d7-4934-a53c-20b77415c0ff.png">

