### PR TITLE
[Feature] 홈 화면 추천 도서 카드 컴포넌트 구현

### DIFF
--- a/src/components/UI/Main/RecommendedBookCard.tsx
+++ b/src/components/UI/Main/RecommendedBookCard.tsx
@@ -1,0 +1,97 @@
+import styled from 'styled-components';
+import {
+  RowFlexCenter,
+  RowFlex,
+  AlignCenter,
+  justifyEnd,
+} from '../../../styles/shared';
+
+function RecommendedBookCard() {
+  // 임시 이미지 Url
+  const imageUrl = 'https://image.yes24.com/goods/79378905/XL';
+
+  return (
+    <CardContainer>
+      <CardSideBlock />
+      <CardBolck>
+        <BookCover src={imageUrl} />
+        <BookInfoContainer>
+          <BookTitle>개발자의 글쓰기</BookTitle>
+          <BookAuthor>정미나 저 / 정정수 역</BookAuthor>
+          <BookPublicationDate>2023.01.05</BookPublicationDate>
+          <BookDescription>
+            여기에는 책 설명이 들어갈껀데 길면 짤리게 하는게 좋을거 같은데
+            무슨말인지 알죠 오케이 가나다라 마바사아자카타파하이요 여기부터는
+            조금 큼직하게 카드 작고 길게 하면 5줄로 해도 좋을거 같은데짤릴껄요?{' '}
+          </BookDescription>
+          <BookComment>좋아요 205 댓글 3K</BookComment>
+        </BookInfoContainer>
+      </CardBolck>
+      <CardSideBlock />
+    </CardContainer>
+  );
+}
+
+const CardContainer = styled.div`
+  ${RowFlexCenter}
+  align-items: center;
+  width: 330px;
+  height: 215px;
+`;
+
+const BookInfoContainer = styled.div`
+  width: 50%;
+  padding: 0 10px;
+  font-size: var(--font-size-xs);
+  color: var(--color-content-text);
+  border: 1px solid var(--color-primary-mint);
+`;
+
+const CardSideBlock = styled.div`
+  width: 5px;
+  height: 97%;
+  border: 1px solid var(--color-primary-mint);
+`;
+
+const CardBolck = styled.div`
+  ${RowFlex}
+  width: 320px;
+`;
+
+const BookCover = styled.img`
+  width: 50%;
+  border: 1px solid var(--color-primary-mint);
+`;
+
+const BookTitle = styled.h2`
+  ${AlignCenter}
+  height: 20%;
+  color: var(--black);
+  font-weight: bold;
+  font-size: var(--font-size-m);
+`;
+
+const BookPublicationDate = styled.p`
+  ${justifyEnd}
+  margin: 5px 0;
+  display: flex;
+  justify-content: end;
+`;
+
+const BookAuthor = styled(BookPublicationDate)`
+  justify-content: start;
+  font-weight: bold;
+`;
+
+const BookDescription = styled.p`
+  height: 50%;
+  margin: 10px 0;
+  line-height: 1.2;
+`;
+
+const BookComment = styled.p`
+  ${justifyEnd}
+  font-weight: bold;
+`;
+
+export default RecommendedBookCard;

--- a/src/components/UI/Main/RecommendedBookCard.tsx
+++ b/src/components/UI/Main/RecommendedBookCard.tsx
@@ -74,8 +74,6 @@ const BookTitle = styled.h2`
 const BookPublicationDate = styled.p`
   ${justifyEnd}
   margin: 5px 0;
-  display: flex;
-  justify-content: end;
 `;
 
 const BookAuthor = styled(BookPublicationDate)`

--- a/src/components/UI/Main/RecommendedBookCard.tsx
+++ b/src/components/UI/Main/RecommendedBookCard.tsx
@@ -22,7 +22,7 @@ function RecommendedBookCard() {
           <BookDescription>
             여기에는 책 설명이 들어갈껀데 길면 짤리게 하는게 좋을거 같은데
             무슨말인지 알죠 오케이 가나다라 마바사아자카타파하이요 여기부터는
-            조금 큼직하게 카드 작고 길게 하면 5줄로 해도 좋을거 같은데짤릴껄요?{' '}
+            조금 큼직하게 카드 작고 길게 하면 5줄로 해도 좋을거 같은데짤릴껄요?
           </BookDescription>
           <BookComment>좋아요 205 댓글 3K</BookComment>
         </BookInfoContainer>

--- a/src/components/UI/Main/RecommendedBookCard.tsx
+++ b/src/components/UI/Main/RecommendedBookCard.tsx
@@ -1,10 +1,5 @@
 import styled from 'styled-components';
-import {
-  RowFlexCenter,
-  RowFlex,
-  AlignCenter,
-  JustifyEnd,
-} from '../../../styles/shared';
+import { Flex, RowFlex, AlignCenter, JustifyEnd } from '../../../styles/shared';
 
 function RecommendedBookCard() {
   // 임시 이미지 Url
@@ -33,8 +28,7 @@ function RecommendedBookCard() {
 }
 
 const CardContainer = styled.div`
-  ${RowFlexCenter}
-  align-items: center;
+  ${Flex}
   width: 330px;
   height: 215px;
 `;
@@ -76,9 +70,10 @@ const BookPublicationDate = styled.p`
   margin: 5px 0;
 `;
 
-const BookAuthor = styled(BookPublicationDate)`
+const BookAuthor = styled.p`
   justify-content: start;
   font-weight: bold;
+  margin: 5px 0;
 `;
 
 const BookDescription = styled.p`

--- a/src/components/UI/Main/RecommendedBookCard.tsx
+++ b/src/components/UI/Main/RecommendedBookCard.tsx
@@ -3,7 +3,7 @@ import {
   RowFlexCenter,
   RowFlex,
   AlignCenter,
-  justifyEnd,
+  JustifyEnd,
 } from '../../../styles/shared';
 
 function RecommendedBookCard() {
@@ -72,7 +72,7 @@ const BookTitle = styled.h2`
 `;
 
 const BookPublicationDate = styled.p`
-  ${justifyEnd}
+  ${JustifyEnd}
   margin: 5px 0;
 `;
 
@@ -88,7 +88,7 @@ const BookDescription = styled.p`
 `;
 
 const BookComment = styled.p`
-  ${justifyEnd}
+  ${JustifyEnd}
   font-weight: bold;
 `;
 

--- a/src/styles/layout.tsx
+++ b/src/styles/layout.tsx
@@ -5,7 +5,6 @@ const MainContainer = styled.main`
   max-width: 1120px;
   width: 100%;
   margin: auto;
-  background-color: blue;
 `;
 
 export default MainContainer;

--- a/src/styles/shared.tsx
+++ b/src/styles/shared.tsx
@@ -18,7 +18,6 @@ export const JustifyEnd = css`
 
 export const RowFlex = css`
   display: flex;
-  flex-direction: row;
 `;
 
 export const RowFlexCenter = css`

--- a/src/styles/shared.tsx
+++ b/src/styles/shared.tsx
@@ -11,7 +11,7 @@ export const AlignCenter = css`
   align-items: center;
 `;
 
-export const justifyEnd = css`
+export const JustifyEnd = css`
   display: flex;
   justify-content: end;
 `;

--- a/src/styles/shared.tsx
+++ b/src/styles/shared.tsx
@@ -6,6 +6,16 @@ export const Flex = css`
   align-items: center;
 `;
 
+export const AlignCenter = css`
+  display: flex;
+  align-items: center;
+`;
+
+export const justifyEnd = css`
+  display: flex;
+  justify-content: end;
+`;
+
 export const RowFlex = css`
   display: flex;
   flex-direction: row;


### PR DESCRIPTION
### 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요. -->
- #31
- #32 

### ✨개발 내용
<!-- 개발한 내용을 설명을 적어주세요 -->
- shared css 추가
- 추천 도서 카드 컴포넌트 구현

### 📸 스크린샷(선택)
<!-- 스크린샷이 필요한 과제면 스크린샷을 첨부해주세요 -->
![image](https://user-images.githubusercontent.com/116181346/226172611-d7fc616d-1d2e-4b45-9cb3-b5d644dc92b7.png)


### 👓 고민 사항(선택)
![image](https://user-images.githubusercontent.com/116181346/226172681-4a68a56b-ed1e-45c7-9d2f-6aa41df2c7d6.png)
- Home page에 쓰이는 추천 도서 카드 컴포넌트를 구현한 간단한 PR입니다.  
- 위 사진과 같이 피그마 상에서 정의했던 카드 컴포넌트에서 하트 버튼을 생략한 점
- 글쓴이와 출판일이 span 요소로 지정해 구현했을 때, 크기 문제로 한 줄에 다 들어가지 않아 분리하였는데, 출판일이 꼭 필요한 것인지에 대한 생각을 공유받고 싶습니다!

`+` 이미지와 안에 들어간 데이터는 임의로 넣어둔 것입니다! 추후 데이터를 받아왔을 때 글자 수 제한을 걸어두어야 할 것 같습니다.