### PR TITLE
[Feature] 게시글 등록 화면 독서 토론탭 CSS 개발, Card CSS 수정

### DIFF
--- a/src/components/PostForm/index.tsx
+++ b/src/components/PostForm/index.tsx
@@ -1,0 +1,160 @@
+import React from 'react';
+import styled, { css } from 'styled-components';
+import useInputs from '../../hooks/useInputs';
+import { ColFlexCenter, ColFlex } from '../../styles/shared';
+import Button, { ButtonBox } from '../UI/Button/Button';
+import { Card } from '../UI/Card/Card';
+import Input from '../UI/Input/Input';
+import Textarea from '../UI/Textarea/Textarea';
+import UserProfile from '../UI/UserProfile/UserProfile';
+
+interface PostFormProps {
+  onSubmit: () => void;
+}
+
+function PostForm({ onSubmit }: PostFormProps) {
+  const [{ title, content }, onChange] = useInputs({
+    title: '',
+    content: '',
+  });
+
+  const handleFormSubmit = (event: React.MouseEvent<HTMLButtonElement>) => {
+    event.preventDefault();
+
+    onSubmit();
+  };
+
+  const imageUrl =
+    'https://image.aladin.co.kr/product/27222/22/cover500/e822538010_1.jpg';
+
+  return (
+    <PostFormContainer>
+      <SerachBookContainer>
+        <SearchBookTitle>토론 도서 선택하기</SearchBookTitle>
+        <SearchBookInputContainer>
+          <BookTitleInput placeholder="도서명을..." />
+          <BookSearchButton
+            type="button"
+            buttonType="buttonRight"
+            buttonColor="white"
+            buttonSize="sm"
+          >
+            찾기
+          </BookSearchButton>
+        </SearchBookInputContainer>
+      </SerachBookContainer>
+      <DiscussionContainer>
+        <UserProfile
+          avatar={imageUrl}
+          alt="프로필 이미지"
+          itemGap="10px"
+          nickname="yua77"
+          size="sm"
+        />
+        <DiscussionInputContainer>
+          <DiscussionTitleInput
+            name="title"
+            value={title}
+            placeholder="토론 제목을 입력하세요..."
+            onChange={onChange}
+          />
+          <DiscussionContentInput
+            name="content"
+            value={content}
+            placeholder="내용을 입력하세요..."
+            onChange={onChange}
+          />
+        </DiscussionInputContainer>
+      </DiscussionContainer>
+
+      <SubmitButton
+        type="button"
+        buttonType="submit"
+        buttonColor="pink"
+        buttonSize="l"
+        onClick={handleFormSubmit}
+      >
+        등록하기
+      </SubmitButton>
+    </PostFormContainer>
+  );
+}
+
+const PostFormContainer = styled.form`
+  max-width: 970px;
+  padding: 32px;
+  gap: 60px;
+  ${ColFlexCenter}
+`;
+
+const CardPadding = css`
+  padding: 32px;
+`;
+
+const SerachBookContainer = styled.section`
+  width: 100%;
+  height: 171px;
+  align-items: center;
+  gap: 16px;
+
+  ${Card}
+  ${ColFlexCenter}
+  ${CardPadding}
+`;
+
+const SearchBookTitle = styled.h3`
+  width: 100%;
+  text-align: center;
+  font-weight: 700;
+  font-size: 24px;
+  line-height: 29px;
+  letter-spacing: -0.02em;
+  color: #1d1d1b;
+`;
+
+const SearchBookInputContainer = styled.div`
+  display: flex;
+  width: 100%;
+`;
+
+const BookTitleInput = styled(Input)`
+  flex: 1 1 0;
+  border-radius: 5px 0 0 5px;
+  border-right: 0;
+`;
+
+const BookSearchButton = styled(ButtonBox)`
+  width: 74px;
+  height: 50px;
+  color: var(--black);
+`;
+
+const DiscussionContainer = styled.section`
+  width: 100%;
+  gap: 22px;
+  display: flex;
+  align-items: flex-start;
+  ${Card}
+  ${CardPadding}
+`;
+
+const DiscussionInputContainer = styled.div`
+  flex: 1 1 0;
+  gap: 22px;
+
+  ${ColFlex}
+`;
+
+const DiscussionTitleInput = styled(Input)`
+  width: 100%;
+`;
+
+const DiscussionContentInput = styled(Textarea)`
+  min-height: 162px;
+`;
+
+const SubmitButton = styled(Button)`
+  align-self: center;
+`;
+
+export default PostForm;

--- a/src/components/PostForm/index.tsx
+++ b/src/components/PostForm/index.tsx
@@ -106,7 +106,7 @@ const SearchBookTitle = styled.h3`
   width: 100%;
   text-align: center;
   font-weight: 700;
-  font-size: 24px;
+  font-size: var(--font-size-xl);
   line-height: 29px;
   letter-spacing: -0.02em;
   color: #1d1d1b;

--- a/src/components/UI/Card/Card.tsx
+++ b/src/components/UI/Card/Card.tsx
@@ -15,9 +15,6 @@ interface SpacerProps {
 }
 
 interface CardProps extends SpacerProps {
-  width: string;
-  height: string;
-  margin?: string;
   radius?: string;
 }
 
@@ -34,11 +31,8 @@ const spacer = (props: SpacerProps) => ({
   paddingLeft: props.paddingLeft,
 });
 
-const Card = css<CardProps>`
-  width: ${(props) => props.width};
-  height: ${(props) => props.height};
+export const Card = css<CardProps>`
   border-radius: ${(props) => props.radius || '20px'};
-  margin: ${(props) => props.margin};
   border: 1px solid var(--color-borderbox-line);
   ${spacer}
 `;

--- a/src/components/UI/Input/Input.tsx
+++ b/src/components/UI/Input/Input.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import styled from 'styled-components';
+
+interface InputProps {
+  [rest: string]: any;
+}
+
+function Input({ ...rest }: InputProps) {
+  return <StyledInput {...rest} />;
+}
+
+const StyledInput = styled.input`
+  background-color: var(--color-inputbox-bg);
+  border: 1px solid var(--color-inputbox-line);
+  border-radius: 5px;
+  font-size: 16px;
+  padding: 12px 16px;
+  font-weight: 400;
+  letter-spacing: -0.02em;
+  line-height: 19px;
+
+  &::placeholder {
+    color: var(--color-placeholder);
+  }
+`;
+
+export default Input;

--- a/src/components/UI/Input/Input.tsx
+++ b/src/components/UI/Input/Input.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import styled from 'styled-components';
+import { InputCSS } from '../../../styles/shared';
 
 interface InputProps {
   [rest: string]: any;
@@ -10,18 +11,8 @@ function Input({ ...rest }: InputProps) {
 }
 
 const StyledInput = styled.input`
-  background-color: var(--color-inputbox-bg);
-  border: 1px solid var(--color-inputbox-line);
-  border-radius: 5px;
-  font-size: 16px;
+  ${InputCSS};
   padding: 12px 16px;
-  font-weight: 400;
-  letter-spacing: -0.02em;
-  line-height: 19px;
-
-  &::placeholder {
-    color: var(--color-placeholder);
-  }
 `;
 
 export default Input;

--- a/src/components/UI/Textarea/Textarea.tsx
+++ b/src/components/UI/Textarea/Textarea.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import styled from 'styled-components';
+import { InputCSS } from '../../../styles/shared';
 
 interface TextareaProps {
   [rest: string]: any;
@@ -10,19 +11,9 @@ function Textarea({ ...rest }: TextareaProps) {
 }
 
 const StyledTextarea = styled.textarea`
-  background-color: var(--color-inputbox-bg);
-  border: 1px solid var(--color-inputbox-line);
-  border-radius: 5px;
-  font-size: 16px;
+  ${InputCSS};
   padding: 16px;
-  font-weight: 400;
-  letter-spacing: -0.02em;
-  line-height: 19px;
   resize: none;
-
-  &::placeholder {
-    color: var(--color-placeholder);
-  }
 `;
 
 export default Textarea;

--- a/src/components/UI/Textarea/Textarea.tsx
+++ b/src/components/UI/Textarea/Textarea.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import styled from 'styled-components';
+
+interface TextareaProps {
+  [rest: string]: any;
+}
+
+function Textarea({ ...rest }: TextareaProps) {
+  return <StyledTextarea {...rest} />;
+}
+
+const StyledTextarea = styled.textarea`
+  background-color: var(--color-inputbox-bg);
+  border: 1px solid var(--color-inputbox-line);
+  border-radius: 5px;
+  font-size: 16px;
+  padding: 16px;
+  font-weight: 400;
+  letter-spacing: -0.02em;
+  line-height: 19px;
+  resize: none;
+
+  &::placeholder {
+    color: var(--color-placeholder);
+  }
+`;
+
+export default Textarea;

--- a/src/components/UI/UserProfile/UserProfile.tsx
+++ b/src/components/UI/UserProfile/UserProfile.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import styled, { css, FlattenSimpleInterpolation } from 'styled-components';
 
-type SizeType = 'xl' | 'lz' | 'md' | 'sm';
+type SizeType = 'xl' | 'lz' | 'md' | 'sm' | 'xs';
 
 interface IProps {
   size: SizeType;
@@ -42,8 +42,13 @@ const SIZES: { [key in SizeType]: FlattenSimpleInterpolation } = {
     --profile-image-size: 90px;
   `,
   sm: css`
-    --profile-font-size: var(--font-size-sm);
+    --profile-font-size: var(--font-size-m);
     --profile-image-size: 70px;
+  `,
+
+  xs: css`
+    --profile-font-size: var(--font-size-sm);
+    --profile-image-size: 46px;
   `,
 };
 
@@ -66,6 +71,7 @@ const UserAvatar = styled.img`
 
 const UserNickname = styled.div`
   font-size: var(--profile-font-size);
+  font-weight: bold;
 `;
 
 export default UserProfile;

--- a/src/hooks/useInputs.ts
+++ b/src/hooks/useInputs.ts
@@ -1,0 +1,18 @@
+import React, { useState, useCallback } from 'react';
+
+function useInputs<T extends Record<string, any>>(initialForm: T) {
+  const [form, setForm] = useState<T>(initialForm);
+  const reset = useCallback(() => {
+    setForm(initialForm);
+  }, [initialForm]);
+
+  const onChange = useCallback((event: React.ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = event.target;
+
+    setForm((preState) => ({ ...preState, [name]: value }));
+  }, []);
+
+  return [form, onChange, reset] as const;
+}
+
+export default useInputs;

--- a/src/hooks/useInputs.ts
+++ b/src/hooks/useInputs.ts
@@ -6,11 +6,11 @@ function useInputs<T extends Record<string, any>>(initialForm: T) {
     setForm(initialForm);
   }, [initialForm]);
 
-  const onChange = useCallback((event: React.ChangeEvent<HTMLInputElement>) => {
+  const onChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const { name, value } = event.target;
 
     setForm((preState) => ({ ...preState, [name]: value }));
-  }, []);
+  };
 
   return [form, onChange, reset] as const;
 }

--- a/src/pages/PostNewPage.tsx
+++ b/src/pages/PostNewPage.tsx
@@ -1,7 +1,15 @@
 import React from 'react';
+import PostForm from '../components/PostForm';
+import MainContainer from '../styles/layout';
 
 function PostNewPage() {
-  return <div>PostNewPage</div>;
+  const handleSubmit = () => {};
+
+  return (
+    <MainContainer>
+      <PostForm onSubmit={handleSubmit} />
+    </MainContainer>
+  );
 }
 
 export default PostNewPage;

--- a/src/styles/shared.tsx
+++ b/src/styles/shared.tsx
@@ -34,3 +34,17 @@ export const ColFlexCenter = css`
   ${ColFlex}
   justify-content: center;
 `;
+
+export const InputCSS = css`
+  background-color: var(--color-inputbox-bg);
+  border: 1px solid var(--color-inputbox-line);
+  border-radius: 5px;
+  font-size: var(--font-size-m);
+  font-weight: 400;
+  letter-spacing: -0.02em;
+  line-height: 19px;
+
+  &::placeholder {
+    color: var(--color-placeholder);
+  }
+`;


### PR DESCRIPTION
### 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요. -->
- #11
- #41 
### ✨개발 내용
<!-- 개발한 내용을 설명을 적어주세요 -->
- 공통 컴포넌트 input 추가
- 공통 컴포넌트 textarea 추가
- useInputs 커스텀 훅 추가
  - input에서 반복되는 onChange, setValue 로직을 모듈화하여 hooks로 구현
  - 사용시 필수적으로 input에 name을 지정해야함
  ```jsx
  function PostForm({ onSubmit }: PostFormProps) {
    const [{ title, content }, onChange] = useInputs({
      title: '',
      content: '',
    });
    //...생략
    return (
    //...생략
      <DiscussionTitleInput
        name="title"
        value={title}
        placeholder="토론 제목을 입력하세요..."
        onChange={onChange}
      />
      <DiscussionContentInput
        name="content"
        value={content}
        placeholder="내용을 입력하세요..."
        onChange={onChange}
      />
    )
  ```  
  - 참고: [벨로퍼트 - 커스텀훅 useInputs](https://react.vlpt.us/basic/21-custom-hook.html)
- PostForm 컴포넌트 구현
- `Card  컴포넌트 수정 (하기 고민사항에 추가적인 내용 작성)`
  - width, height, margin 삭제
  - Card css 자체를 export 하도록 수정


### 📸 스크린샷(선택)
<!-- 스크린샷이 필요한 과제면 스크린샷을 첨부해주세요 -->
<img width="971" alt="image" src="https://user-images.githubusercontent.com/19286161/231476871-4ca9dfc8-d961-44bf-83e5-7d98117a297e.png">

### 👓 고민 사항(선택)
- Card 컴포넌트 수정관련해서 논의후 적용하려고합니다
  - width, height, margin props 삭제
    - 해당 부분은 별도 로직을 타거나 지정된 너비,높이로 설정하는게 아닌 것들로 보여서 없어도 되지 않을까 싶은데 어떻게 생각하시나요?
  - Card CSS 자체를 Export해서 사용
    - Card 같은 경우 다양하게 사용되어서 tag를 지정해서 사용하는 것보다 css자체를 export하는 것이 더 좋지 않을까라는 생각이 들었습니다. 두 가지로 만들어주셨는데 저같은 경우 card 별로 section으로 구분지어서 사용하려고 section tag에 card를 적용이 필요했습니다.
    - css만 Import 해오면 별도의 tag에 대한 고민이 없어지는 장점이 있는거 같아요
    - CSS만 Export 해왔을때 사용방법
```jsx
import { Card } from '../UI/Card/Card';

const DiscussionContainer = styled.section`
  width: 100%;
  gap: 22px;
  display: flex;
  align-items: flex-start;
  ${Card}
  ${CardPadding}
`;
```
### 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
<!-- 참고할 사항이 있다면 적어주세요 -->
