### PR TITLE
[Feature] 찬반토론 ProConDiscussionCard, ProConLeaderTag 컴포넌트 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "@typescript-eslint/eslint-plugin": "^5.52.0",
         "@typescript-eslint/parser": "^5.52.0",
         "@vitejs/plugin-react": "^3.1.0",
-        "dayjs": "1.10.6",
+        "dayjs": "1.11.7",
         "eslint": "^8.34.0",
         "eslint-config-airbnb": "^19.0.4",
         "eslint-config-prettier": "^8.6.0",
@@ -1970,9 +1970,9 @@
       "dev": true
     },
     "node_modules/dayjs": {
-      "version": "1.10.6",
-      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.10.6.tgz",
-      "integrity": "sha512-AztC/IOW4L1Q41A86phW5Thhcrco3xuAA+YX/BLpLWWjRcTj5TOt/QImBLmCKlrF7u7k47arTnOyL6GnbG8Hvw==",
+      "version": "1.11.7",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.7.tgz",
+      "integrity": "sha512-+Yw9U6YO5TQohxLcIkrXBeY73WP3ejHWVvx8XCk3gxvQDCTEmS48ZrSZCKciI7Bhl/uCMyxYtE9UqRILmFphkQ==",
       "dev": true
     },
     "node_modules/debug": {
@@ -6183,9 +6183,9 @@
       "dev": true
     },
     "dayjs": {
-      "version": "1.10.6",
-      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.10.6.tgz",
-      "integrity": "sha512-AztC/IOW4L1Q41A86phW5Thhcrco3xuAA+YX/BLpLWWjRcTj5TOt/QImBLmCKlrF7u7k47arTnOyL6GnbG8Hvw==",
+      "version": "1.11.7",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.7.tgz",
+      "integrity": "sha512-+Yw9U6YO5TQohxLcIkrXBeY73WP3ejHWVvx8XCk3gxvQDCTEmS48ZrSZCKciI7Bhl/uCMyxYtE9UqRILmFphkQ==",
       "dev": true
     },
     "debug": {

--- a/src/components/Comment/CommentItem.tsx
+++ b/src/components/Comment/CommentItem.tsx
@@ -7,7 +7,8 @@ import {
   AiOutlineLike,
 } from 'react-icons/ai';
 import { BsDot } from 'react-icons/bs';
-import { AlignCenter, ColFlex, Flex } from '../../styles/shared';
+import ProConLeaderTag from '../UI/Tag/ProConLeaderTag';
+import { AlignCenter, ColFlex } from '../../styles/shared';
 
 interface Comment {
   id: number;
@@ -53,9 +54,13 @@ function CommentItem({
               <Nickname>{comment.author}</Nickname>
               {isProConDiscussion &&
                 (comment.isPro ? (
-                  <ProSide>찬성측</ProSide>
+                  <ProConLeaderTag isAgree tagSize="sm">
+                    찬성측
+                  </ProConLeaderTag>
                 ) : (
-                  <ConSide>반대측</ConSide>
+                  <ProConLeaderTag isAgree tagSize="sm">
+                    반대측
+                  </ProConLeaderTag>
                 ))}
             </UserInfoBox>
             <CommentDate>{comment.updatedAt}</CommentDate>
@@ -125,25 +130,6 @@ const Nickname = styled.strong`
 const CommentDate = styled.p`
   font-size: var(--font-size-sm);
   color: var(--color-content-text);
-`;
-
-const proConCSS = css`
-  ${Flex}
-  width: 48px;
-  height: 24px;
-  color: white;
-  border-radius: 20px;
-  font-size: var(--font-size-sm);
-`;
-
-const ProSide = styled.span`
-  ${proConCSS}
-  background-color: var(--color-primary-mint);
-`;
-
-const ConSide = styled.span`
-  ${proConCSS}
-  background-color: var(--color-primary-pink);
 `;
 
 const ButtonContainer = styled.div`

--- a/src/components/ProConDiscussion/ProConDiscussionCard.tsx
+++ b/src/components/ProConDiscussion/ProConDiscussionCard.tsx
@@ -2,23 +2,110 @@ import styled from 'styled-components';
 import { Link } from 'react-router-dom';
 import { Card } from '../UI/Card/Card';
 import { Post } from '../../pages/ProConDiscussionPage';
+import UserProfile from '../UI/UserProfile/UserProfile';
+import ProConLeaderTag from '../UI/Tag/ProConLeaderTag';
+import ProgressBar from '../UI/ProgressBar/ProgressBar';
+import {
+  Flex,
+  ColFlex,
+  profileBoxCSS,
+  truncateTextCSS,
+} from '../../styles/shared';
 
 interface ProConDiscussionCardProps {
   procondiscussionData: Post;
 }
 
+const userImageUrl =
+  'https://www.thechooeok.com/common/img/default_profile.png';
+
+const noneImageUrl =
+  'https://www.pngitem.com/pimgs/m/80-806189_red-x-circle-icon-hd-png-download.png';
+
 function ProConDiscussionCard({
   procondiscussionData,
 }: ProConDiscussionCardProps) {
+  const proLeader = procondiscussionData.agreeUser;
+  const conLeader = procondiscussionData.disagreeUser;
+  const proCount = procondiscussionData.agreeCount;
+  const proRate = String(
+    (proCount / (proCount + procondiscussionData.disagreeCount)) * 100,
+  );
+
   return (
     <CardContainer to={`/pro-con-discussion/${procondiscussionData.id}`}>
-      dkdkdk
+      <ProfileBox>
+        <ProConLeaderTag isAgree tagSize="m">
+          찬성측
+        </ProConLeaderTag>
+        <UserProfile
+          avatar={userImageUrl || noneImageUrl}
+          alt="찬성측 프로필 이미지"
+          itemGap="24px"
+          nickname={proLeader || ''}
+          size="md"
+        />
+      </ProfileBox>
+      <DiscussionInfoWrap>
+        <Title>{procondiscussionData.title}</Title>
+        <Content>{procondiscussionData.content}</Content>
+        <ProgressBar
+          isDisplayContent
+          barWidth="70%"
+          barHeight="20px"
+          value={proRate}
+          size="md"
+        />
+      </DiscussionInfoWrap>
+      <ProfileBox>
+        <ProConLeaderTag isAgree={false} tagSize="m">
+          반대측
+        </ProConLeaderTag>
+        <UserProfile
+          avatar={userImageUrl || noneImageUrl}
+          alt="찬성측 프로필 이미지"
+          itemGap="24px"
+          nickname={conLeader || ''}
+          size="md"
+        />
+      </ProfileBox>
     </CardContainer>
   );
 }
 
 const CardContainer = styled(Link)`
-  ${Card}
+  ${Card};
+  ${Flex}
+  gap: 50px;
+  width: 970px;
+  height: 250px;
+  padding: 30px;
+  margin: 50px 0;
+`;
+
+const Title = styled.h3`
+  ${truncateTextCSS};
+  font-weight: 600;
+  font-size: var(--font-size-xxl);
+`;
+
+const Content = styled.p`
+  ${truncateTextCSS};
+  -webkit-line-clamp: 5;
+  font-size: var(--font-size-m);
+`;
+
+const ProfileBox = styled.div`
+  ${profileBoxCSS}
+  height: 100%;
+  padding-top: 10px;
+  justify-content: flex-start;
+`;
+
+const DiscussionInfoWrap = styled.div`
+  ${ColFlex};
+  gap: 20px;
+  align-items: center;
 `;
 
 export default ProConDiscussionCard;

--- a/src/components/ProConDiscussion/ProConDiscussionCard.tsx
+++ b/src/components/ProConDiscussion/ProConDiscussionCard.tsx
@@ -1,0 +1,24 @@
+import styled from 'styled-components';
+import { Link } from 'react-router-dom';
+import { Card } from '../UI/Card/Card';
+import { Post } from '../../pages/ProConDiscussionPage';
+
+interface ProConDiscussionCardProps {
+  procondiscussionData: Post;
+}
+
+function ProConDiscussionCard({
+  procondiscussionData,
+}: ProConDiscussionCardProps) {
+  return (
+    <CardContainer to={`/pro-con-discussion/${procondiscussionData.id}`}>
+      dkdkdk
+    </CardContainer>
+  );
+}
+
+const CardContainer = styled(Link)`
+  ${Card}
+`;
+
+export default ProConDiscussionCard;

--- a/src/components/ProConDiscussionDetail/DiscussionInformation.tsx
+++ b/src/components/ProConDiscussionDetail/DiscussionInformation.tsx
@@ -1,9 +1,15 @@
-import styled, { css } from 'styled-components';
+import styled from 'styled-components';
 import { BsDot } from 'react-icons/bs';
 import { Card } from '../UI/Card/Card';
 import UserProfile from '../UI/UserProfile/UserProfile';
 import ProgressBar from '../UI/ProgressBar/ProgressBar';
-import { AlignCenter, ColFlex, Flex, RowFlexCenter } from '../../styles/shared';
+import ProConLeaderTag from '../UI/Tag/ProConLeaderTag';
+import {
+  ColFlex,
+  AlignCenter,
+  RowFlexCenter,
+  profileBoxCSS,
+} from '../../styles/shared';
 
 function DiscussionInformation() {
   const userImageUrl =
@@ -20,7 +26,9 @@ function DiscussionInformation() {
       </ButtonContainer>
       <DiscussionInfoContainer>
         <ProfileBox>
-          <ProLeader>찬성측</ProLeader>
+          <ProConLeaderTag isAgree tagSize="m">
+            찬성측
+          </ProConLeaderTag>
           <UserProfile
             avatar={noneImageUrl}
             alt="찬성측 프로필 이미지"
@@ -41,7 +49,9 @@ function DiscussionInformation() {
           />
         </DiscussionInfo>
         <ProfileBox>
-          <ConLeader>반대측</ConLeader>
+          <ProConLeaderTag isAgree={false} tagSize="m">
+            반대측
+          </ProConLeaderTag>
           <UserProfile
             avatar={userImageUrl}
             alt="반대측 프로필 이미지"
@@ -95,28 +105,7 @@ const Button = styled.button`
 `;
 
 const ProfileBox = styled.div`
-  ${ColFlex}
-  align-items: center;
-  flex-shrink: 0;
-  gap: 24px;
-`;
-
-const proConCSS = css`
-  ${Flex}
-  width: 60px;
-  height: 30px;
-  color: white;
-  border-radius: 20px;
-`;
-
-const ProLeader = styled.span`
-  ${proConCSS}
-  background-color: var(--color-primary-mint);
-`;
-
-const ConLeader = styled.span`
-  ${proConCSS}
-  background-color: var(--color-primary-pink);
+  ${profileBoxCSS}
 `;
 
 export default DiscussionInformation;

--- a/src/components/UI/Tag/ProConLeaderTag.tsx
+++ b/src/components/UI/Tag/ProConLeaderTag.tsx
@@ -1,0 +1,31 @@
+import styled, { css, FlattenSimpleInterpolation } from 'styled-components';
+import { proConCSS } from '../../../styles/shared';
+
+type TagSize = 'm' | 'sm';
+
+interface TagProps {
+  isAgree: boolean;
+  tagSize: TagSize;
+}
+
+const tagSizeCSS: { [key in TagSize]: FlattenSimpleInterpolation } = {
+  m: css`
+    width: 60px;
+    height: 30px;
+    font-size: var(--font-size-m);
+  `,
+  sm: css`
+    width: 48px;
+    height: 24px;
+    font-size: var(--font-size-sm);
+  `,
+};
+
+const ProConLeaderTag = styled.span<TagProps>`
+  ${proConCSS}
+  ${({ tagSize }) => tagSizeCSS[tagSize]};
+  background-color: ${({ isAgree }) =>
+    isAgree ? 'var(--color-primary-mint)' : 'var(--color-primary-pink)'};
+`;
+
+export default ProConLeaderTag;

--- a/src/pages/ProConDiscussionPage.tsx
+++ b/src/pages/ProConDiscussionPage.tsx
@@ -2,6 +2,7 @@ import styled from 'styled-components';
 import MainContainer from '../styles/layout';
 import { Subtitle, PageInfo } from './BookDiscussionPage';
 import ProConDiscussionCard from '../components/ProConDiscussion/ProConDiscussionCard';
+import { ColFlex } from '../styles/shared';
 
 export interface Post {
   id: number;
@@ -23,47 +24,96 @@ interface ProConDiscussionData {
   pageInfo: PageInfo;
 }
 
+// 유저들의 프로필이 있어야 됨
 const dummyData: ProConDiscussionData = {
   posts: [
     {
       id: 43,
       author: 'jjs',
-      title: 'string',
-      content: 'string',
+      title: '다나카는 일본인인가?다나카는 일본인인가?다나카는 일본인인가?',
+      content:
+        '랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄<<주제설명주제설명주제설명주제설명주제설명>>랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄',
       views: 0,
       thumbup: 0,
       createdAt: '2023-04-18T02:35:20.116Z',
       updatedAt: '2023-04-18T02:35:20.116Z',
       agreeCount: 1,
       disagreeCount: 0,
-      agreeUser: 'jjs',
-      disagreeUser: 'yua77',
+      agreeUser: 'jjsssssssssss',
+      disagreeUser: '',
     },
     {
       id: 44,
       author: 'jjs',
-      title: 'string',
-      content: 'string',
+      title: '다나카는 일본인인가?',
+      content:
+        '랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄<<주제설명주제설명주제설명주제설명주제설명>>랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄',
       views: 0,
       thumbup: 0,
       createdAt: '2023-04-18T02:35:24.139Z',
       updatedAt: '2023-04-18T02:35:24.139Z',
       agreeCount: 1,
-      disagreeCount: 0,
+      disagreeCount: 1,
       agreeUser: 'jjs',
       disagreeUser: 'yua77',
     },
     {
       id: 53,
       author: 'jjs',
-      title: 'string',
-      content: 'string',
+      title: '다나카는 일본인인가?',
+      content:
+        '랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄<<주제설명주제설명주제설명주제설명주제설명>>랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄',
       views: 0,
       thumbup: 0,
       createdAt: '2023-04-18T19:09:49.823Z',
       updatedAt: '2023-04-18T19:09:49.823Z',
       agreeCount: 1,
-      disagreeCount: 0,
+      disagreeCount: 3,
+      agreeUser: 'jjs',
+      disagreeUser: null,
+    },
+    {
+      id: 54,
+      author: 'jjs',
+      title: '다나카는 일본인인가?',
+      content:
+        '랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄<<주제설명주제설명주제설명주제설명주제설명>>랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄',
+      views: 0,
+      thumbup: 0,
+      createdAt: '2023-04-18T19:09:49.823Z',
+      updatedAt: '2023-04-18T19:09:49.823Z',
+      agreeCount: 1,
+      disagreeCount: 3,
+      agreeUser: 'jjs',
+      disagreeUser: null,
+    },
+    {
+      id: 55,
+      author: 'jjs',
+      title: '다나카는 일본인인가?',
+      content:
+        '랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄<<주제설명주제설명주제설명주제설명주제설명>>랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄',
+      views: 0,
+      thumbup: 0,
+      createdAt: '2023-04-18T19:09:49.823Z',
+      updatedAt: '2023-04-18T19:09:49.823Z',
+      agreeCount: 1,
+      disagreeCount: 3,
+      agreeUser: 'jjs',
+      disagreeUser: null,
+    },
+    {
+      id: 56,
+      author: 'jjs',
+      title: '다나카는 일본인인가?',
+      content:
+        '랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄<<주제설명주제설명주제설명주제설명주제설명>>랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄랄',
+      views: 0,
+      thumbup: 0,
+      createdAt: '2023-04-18T19:09:49.823Z',
+      updatedAt: '2023-04-18T19:09:49.823Z',
+      agreeCount: 1,
+      disagreeCount: 3,
       agreeUser: 'jjs',
       disagreeUser: null,
     },
@@ -90,7 +140,9 @@ function ProConDiscussion() {
 }
 
 const ProConDiscussionCardContainer = styled.section`
-  margin: 0 20px;
+  ${ColFlex}
+  align-items: center;
+  margin-bottom: 50px;
 `;
 
 export default ProConDiscussion;

--- a/src/pages/ProConDiscussionPage.tsx
+++ b/src/pages/ProConDiscussionPage.tsx
@@ -1,7 +1,96 @@
-import React from 'react';
+import styled from 'styled-components';
+import MainContainer from '../styles/layout';
+import { Subtitle, PageInfo } from './BookDiscussionPage';
+import ProConDiscussionCard from '../components/ProConDiscussion/ProConDiscussionCard';
+
+export interface Post {
+  id: number;
+  author: string;
+  title: string;
+  content: string;
+  views: number;
+  thumbup: number;
+  createdAt: string;
+  updatedAt: string;
+  agreeCount: number;
+  disagreeCount: number;
+  agreeUser: string;
+  disagreeUser: null | string;
+}
+
+interface ProConDiscussionData {
+  posts: Post[];
+  pageInfo: PageInfo;
+}
+
+const dummyData: ProConDiscussionData = {
+  posts: [
+    {
+      id: 43,
+      author: 'jjs',
+      title: 'string',
+      content: 'string',
+      views: 0,
+      thumbup: 0,
+      createdAt: '2023-04-18T02:35:20.116Z',
+      updatedAt: '2023-04-18T02:35:20.116Z',
+      agreeCount: 1,
+      disagreeCount: 0,
+      agreeUser: 'jjs',
+      disagreeUser: 'yua77',
+    },
+    {
+      id: 44,
+      author: 'jjs',
+      title: 'string',
+      content: 'string',
+      views: 0,
+      thumbup: 0,
+      createdAt: '2023-04-18T02:35:24.139Z',
+      updatedAt: '2023-04-18T02:35:24.139Z',
+      agreeCount: 1,
+      disagreeCount: 0,
+      agreeUser: 'jjs',
+      disagreeUser: 'yua77',
+    },
+    {
+      id: 53,
+      author: 'jjs',
+      title: 'string',
+      content: 'string',
+      views: 0,
+      thumbup: 0,
+      createdAt: '2023-04-18T19:09:49.823Z',
+      updatedAt: '2023-04-18T19:09:49.823Z',
+      agreeCount: 1,
+      disagreeCount: 0,
+      agreeUser: 'jjs',
+      disagreeUser: null,
+    },
+  ],
+  pageInfo: {
+    page: 1,
+    totalCount: 6,
+    currentCount: 3,
+    totalPage: 2,
+  },
+};
 
 function ProConDiscussion() {
-  return <div>ProConDiscussion</div>;
+  return (
+    <MainContainer>
+      <Subtitle>찬반토론</Subtitle>
+      <ProConDiscussionCardContainer>
+        {dummyData.posts.map((post) => (
+          <ProConDiscussionCard procondiscussionData={post} key={post.id} />
+        ))}
+      </ProConDiscussionCardContainer>
+    </MainContainer>
+  );
 }
+
+const ProConDiscussionCardContainer = styled.section`
+  margin: 0 20px;
+`;
 
 export default ProConDiscussion;

--- a/src/styles/shared.tsx
+++ b/src/styles/shared.tsx
@@ -76,3 +76,16 @@ export const likeIconCSS = css`
   top: 15px;
   filter: drop-shadow(0 1px 1px rgba(0, 0, 0, 0.6));
 `;
+
+export const proConCSS = css`
+  ${Flex}
+  color: white;
+  border-radius: 20px;
+`;
+
+export const profileBoxCSS = css`
+  ${ColFlex}
+  align-items: center;
+  flex-shrink: 0;
+  gap: 24px;
+`;


### PR DESCRIPTION
### 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요. -->
- #1
- #31
- #34
- #37

### ✨개발 내용
<!-- 개발한 내용을 설명을 적어주세요 -->
- ProConDiscussionCard 컴포넌트 개발
- ProConLeaderTag 컴포넌트 개발
- 공용 CSS  proConCSS, profileBoxCSS `Shared` 에 추가

#### src/components/ProConDiscussion/ProConDiscussionCard.tsx
```tsx
 <CardContainer to={`/pro-con-discussion/${procondiscussionData.id}`}>
      <ProfileBox>
        <ProConLeaderTag isAgree tagSize="m">
          찬성측
        </ProConLeaderTag>
        <UserProfile
          avatar={userImageUrl || noneImageUrl}
          alt="찬성측 프로필 이미지"
          itemGap="24px"
          nickname={proLeader || ''}
          size="md"
        />
      </ProfileBox>
      <DiscussionInfoWrap>
        <Title>{procondiscussionData.title}</Title>
        <Content>{procondiscussionData.content}</Content>
        <ProgressBar
          isDisplayContent
          barWidth="70%"
          barHeight="20px"
          value={proRate}
          size="md"
        />
      </DiscussionInfoWrap>
      <ProfileBox>
        <ProConLeaderTag isAgree={false} tagSize="m">
          반대측
        </ProConLeaderTag>
        <UserProfile
          avatar={userImageUrl || noneImageUrl}
          alt="찬성측 프로필 이미지"
          itemGap="24px"
          nickname={conLeader || ''}
          size="md"
        />
      </ProfileBox>
    </CardContainer>
```

### 📸 스크린샷
<!-- 스크린샷이 필요한 과제면 스크린샷을 첨부해주세요 -->
![image](https://user-images.githubusercontent.com/116181346/234289746-1e432229-e4bf-42e6-8dc5-f81da931031c.png)


### 👓 고민 사항
> 유저 닉네임 글자 제한을 정해 둬야 할 것 같습니다! 찬반토론 제목과 찬반토론 설명 같은 경우에는 제목은 한 줄, 찬반토론 설명은 다섯 줄로 제한을 해 둔 상태인데 생각해 보니 닉네임에 글자수에 대한 얘기를 안 했던 것 같아 정하면 좋을 것 같애요! 

> noneImageUrl의 경우에는 유저가 없을 떄 응답으로 null 와 같은 응답 데이터를 받아 오기 때문애 userImageUrl를 사용해서 해당 이미지를 보여 주는데 찬반토론 목록, 찬반토론 상세페이지에서 사용하고 있어 환경변수로 빼두는 건 좋은 방법일까요?! 여러 군데에서 Url 링크를 복붙해서 사용하고 있어서 환경변수로 빼두는 것은 어떤지 의견을 들어보고 싶습니다!