### PR TITLE
[Feature] Pagination 컴포넌트 수정

### DIFF
--- a/src/components/UI/Pagination/Pagination.tsx
+++ b/src/components/UI/Pagination/Pagination.tsx
@@ -27,10 +27,11 @@ function Pagination({
 
   return (
     <PaginationContainer>
-      <PageButton onClick={() => setPaginate(1)}>
+      <PageButton aria-label="처음" onClick={() => setPaginate(1)}>
         <RxDoubleArrowLeft size={11} />
       </PageButton>
       <PageButton
+        aria-label="이전"
         onClick={() =>
           currentPage === 1 ? setPaginate(1) : setPaginate(page - 1)
         }
@@ -39,6 +40,7 @@ function Pagination({
       </PageButton>
       {pageNumbers.map((num: number) => (
         <ButtonNav
+          aria-label={`${num} 페이지`}
           key={num}
           onClick={() => setPaginate(num)}
           isCurrentPage={num === page}
@@ -47,6 +49,7 @@ function Pagination({
         </ButtonNav>
       ))}
       <PageButton
+        aria-label="다음"
         onClick={() =>
           currentPage === totalPage
             ? setPaginate(totalPage)
@@ -55,7 +58,7 @@ function Pagination({
       >
         <IoIosArrowForward size={11} />
       </PageButton>
-      <PageButton onClick={() => setPaginate(totalPage)}>
+      <PageButton aria-label="끝" onClick={() => setPaginate(totalPage)}>
         <RxDoubleArrowRight size={11} />
       </PageButton>
     </PaginationContainer>

--- a/src/components/UI/Pagination/Pagination.tsx
+++ b/src/components/UI/Pagination/Pagination.tsx
@@ -13,12 +13,12 @@ export interface PageInfo {
 
 interface PaginationProps {
   paginationInfo: PageInfo;
-  paginate: number;
+  currentPage: number;
   setPaginate: React.Dispatch<React.SetStateAction<number>>;
 }
 
 function Pagination({
-  paginate,
+  currentPage,
   setPaginate,
   paginationInfo,
 }: PaginationProps) {
@@ -32,7 +32,7 @@ function Pagination({
       </PageButton>
       <PageButton
         onClick={() =>
-          paginate === 1 ? setPaginate(1) : setPaginate(page - 1)
+          currentPage === 1 ? setPaginate(1) : setPaginate(page - 1)
         }
       >
         <IoIosArrowBack size={11} />
@@ -48,7 +48,7 @@ function Pagination({
       ))}
       <PageButton
         onClick={() =>
-          paginate === totalPage
+          currentPage === totalPage
             ? setPaginate(totalPage)
             : setPaginate(page + 1)
         }

--- a/src/components/UI/Pagination/Pagination.tsx
+++ b/src/components/UI/Pagination/Pagination.tsx
@@ -1,102 +1,82 @@
-import { useState, useEffect } from 'react';
-import styled, { css } from 'styled-components';
+import React from 'react';
+import styled from 'styled-components';
 import { IoIosArrowBack, IoIosArrowForward } from 'react-icons/io';
 import { RxDoubleArrowLeft, RxDoubleArrowRight } from 'react-icons/rx';
+import { Flex } from '../../../styles/shared';
 
-interface Data {
-  body: string;
-  id: number;
-  title: string;
-  userId: number;
+export interface PageInfo {
+  page: number;
+  totalPage: number;
+  totalCount: number;
+  currentCount: number;
 }
 
-function Pagination() {
-  const [posts, setPosts] = useState<Data[]>([]);
-  const [currentPage, setCurrentPage] = useState(1);
-  const postsPerPage = 15;
+interface PaginationProps {
+  paginationInfo: PageInfo;
+  paginate: number;
+  setPaginate: React.Dispatch<React.SetStateAction<number>>;
+}
 
-  useEffect(() => {
-    const fetchPosts = async () => {
-      const data = await fetch(
-        'https://jsonplaceholder.typicode.com/posts',
-      ).then((res) => res.json());
-      setPosts(data);
-    };
-
-    fetchPosts();
-  }, []);
-
-  const indexOfLastPost = currentPage * postsPerPage; // 페이지의 마지막 게시물 위치
-  const indexOfFirstPost = indexOfLastPost - postsPerPage; // 페이지의 첫번째 게시물 위치
-  const currentPosts = posts.slice(indexOfFirstPost, indexOfLastPost); // 보여져야 하는 게시물만큼 Slice
-
-  const pageNumbers = [];
-  const page = Math.ceil(posts.length / postsPerPage);
-
-  for (let i: number = 1; i <= page; i += 1) {
-    pageNumbers.push(i);
-  }
-
-  const paginate = (pageNumber: number) => {
-    if (pageNumber === 0) return;
-    if (pageNumber > page) return;
-    setCurrentPage(pageNumber);
-  };
+function Pagination({
+  paginate,
+  setPaginate,
+  paginationInfo,
+}: PaginationProps) {
+  const { page, totalPage } = paginationInfo;
+  const pageNumbers = Array.from({ length: totalPage }, (_, idx) => idx + 1);
 
   return (
-    <>
-      {currentPosts.map((post) => (
-        <div className="post" key={post.id}>
-          {post.body}
-        </div>
+    <PaginationContainer>
+      <PageButton onClick={() => setPaginate(1)}>
+        <RxDoubleArrowLeft size={11} />
+      </PageButton>
+      <PageButton
+        onClick={() =>
+          paginate === 1 ? setPaginate(1) : setPaginate(page - 1)
+        }
+      >
+        <IoIosArrowBack size={11} />
+      </PageButton>
+      {pageNumbers.map((num: number) => (
+        <ButtonNav
+          key={num}
+          onClick={() => setPaginate(num)}
+          isCurrentPage={num === page}
+        >
+          {num}
+        </ButtonNav>
       ))}
-      <PaginationBlock>
-        <PageButton onClick={() => paginate(1)}>
-          <RxDoubleArrowLeft size={11} />
-        </PageButton>
-        <PageButton onClick={() => paginate(currentPage - 1)}>
-          <IoIosArrowBack size={11} />
-        </PageButton>
-        {pageNumbers.map((num: number) => (
-          <ButtonNav
-            key={num}
-            onClick={() => paginate(num)}
-            isCurrentPage={num === currentPage}
-          >
-            {num}
-          </ButtonNav>
-        ))}
-        <PageButton onClick={() => paginate(currentPage + 1)}>
-          <IoIosArrowForward size={11} />
-        </PageButton>
-        <PageButton onClick={() => paginate(page)}>
-          <RxDoubleArrowRight size={11} />
-        </PageButton>
-      </PaginationBlock>
-    </>
+      <PageButton
+        onClick={() =>
+          paginate === totalPage
+            ? setPaginate(totalPage)
+            : setPaginate(page + 1)
+        }
+      >
+        <IoIosArrowForward size={11} />
+      </PageButton>
+      <PageButton onClick={() => setPaginate(totalPage)}>
+        <RxDoubleArrowRight size={11} />
+      </PageButton>
+    </PaginationContainer>
   );
 }
 
-const Flex = css`
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  font-size: var(--font-size-sm);
-`;
-
-const PaginationBlock = styled.div`
+const PaginationContainer = styled.div`
   ${Flex}
-  margin: 20px;
+  margin-bottom: 80px;
+  font-size: var(--font-size-sm);
 `;
 
 const PageButton = styled.button`
   ${Flex}
-  padding: 5px;
+  border: 0;
   width: 30px;
   height: 30px;
-  border: 0;
-  background-color: transparent;
+  padding: 5px;
   border: 1px solid #c4c4c497;
+  background-color: transparent;
+  font-size: var(--font-size-sm);
 
   &:hover {
     color: var(--color-primary-pink);

--- a/src/pages/BookDiscussionPage.tsx
+++ b/src/pages/BookDiscussionPage.tsx
@@ -165,7 +165,7 @@ function BookDiscussion() {
         ))}
       </BookDiscussionCardContainer>
       <Pagination
-        paginate={paginate}
+        currentPage={paginate}
         setPaginate={setPaginate}
         paginationInfo={paginationInfo}
       />

--- a/src/pages/BookDiscussionPage.tsx
+++ b/src/pages/BookDiscussionPage.tsx
@@ -1,13 +1,8 @@
+import { useState } from 'react';
 import styled from 'styled-components';
 import MainContainer from '../styles/layout';
 import BookDiscussionCard from '../components/BookDiscussion/BookDiscussionCard';
-
-export interface PageInfo {
-  page: number;
-  totalPage: number;
-  totalCount: number;
-  currentCount: number;
-}
+import Pagination, { PageInfo } from '../components/UI/Pagination/Pagination';
 
 export interface BookDiscussionInfo {
   id: string;
@@ -136,15 +131,44 @@ const dummyData: BookDiscussionData = {
 };
 
 function BookDiscussion() {
+  const [posts] = useState<BookDiscussionInfo[]>(dummyData.data);
+  const [paginate, setPaginate] = useState(1);
+  const [paginationInfo] = useState<PageInfo>(dummyData.pageInfo);
+
+  /* 9개씩 가지고 옴
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        // params에 현재 page 쪽수, 보여질 게시물 개수인 limit 담기
+        const res = await fetch('').then((res) => res.json());
+        const postData = res.data;
+        const paginationData: PageInfo = res.pageInfo;
+        
+        // setPosts 만들어서
+        setPosts(postData);
+        // setPosts 만들어서
+        setPaginationInfo(postData)
+      } catch (e) {
+        console.log(e)
+      }
+        
+    };
+  }, [paginate]); // paginate 쪽수 변경할 때마다 새로운 데이터 가지고 오게 의존성 추가
+  */
+
   return (
     <MainContainer>
       <Subtitle>독서토론</Subtitle>
       <BookDiscussionCardContainer>
-        {dummyData.data.map((data) => (
-          <BookDiscussionCard bookDiscussionData={data} key={data.id} />
+        {posts.map((post) => (
+          <BookDiscussionCard bookDiscussionData={post} key={post.id} />
         ))}
       </BookDiscussionCardContainer>
-      {/* 페이지네이션 */}
+      <Pagination
+        paginate={paginate}
+        setPaginate={setPaginate}
+        paginationInfo={paginationInfo}
+      />
     </MainContainer>
   );
 }

--- a/src/pages/ProConDiscussionPage.tsx
+++ b/src/pages/ProConDiscussionPage.tsx
@@ -163,7 +163,7 @@ function ProConDiscussion() {
         ))}
       </ProConDiscussionCardContainer>
       <Pagination
-        paginate={paginate}
+        currentPage={paginate}
         setPaginate={setPaginate}
         paginationInfo={paginationInfo}
       />

--- a/src/pages/ProConDiscussionPage.tsx
+++ b/src/pages/ProConDiscussionPage.tsx
@@ -1,8 +1,10 @@
+import { useState } from 'react';
 import styled from 'styled-components';
 import MainContainer from '../styles/layout';
-import { Subtitle, PageInfo } from './BookDiscussionPage';
-import ProConDiscussionCard from '../components/ProConDiscussion/ProConDiscussionCard';
 import { ColFlex } from '../styles/shared';
+import { Subtitle } from './BookDiscussionPage';
+import ProConDiscussionCard from '../components/ProConDiscussion/ProConDiscussionCard';
+import Pagination, { PageInfo } from '../components/UI/Pagination/Pagination';
 
 export interface Post {
   id: number;
@@ -39,8 +41,8 @@ const dummyData: ProConDiscussionData = {
       updatedAt: '2023-04-18T02:35:20.116Z',
       agreeCount: 1,
       disagreeCount: 0,
-      agreeUser: 'jjsssssssssss',
-      disagreeUser: '',
+      agreeUser: '가가가가가가가가',
+      disagreeUser: '가가가가가가가가',
     },
     {
       id: 44,
@@ -127,14 +129,44 @@ const dummyData: ProConDiscussionData = {
 };
 
 function ProConDiscussion() {
+  const [posts] = useState<Post[]>(dummyData.posts);
+  const [paginate, setPaginate] = useState(1);
+  const [paginationInfo] = useState<PageInfo>(dummyData.pageInfo);
+
+  /* 4개씩 가지고 옴
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        // params에 현재 page 쪽수, 보여질 게시물 개수인 limit 담기
+        const res = await fetch('').then((res) => res.json());
+        const postData = res.data;
+        const paginationData: PageInfo = res.pageInfo;
+        
+        // setPosts 만들어서
+        setPosts(postData);
+        // setPosts 만들어서
+        setPaginationInfo(postData)
+      } catch (e) {
+        console.log(e)
+      }
+        
+    };
+  }, [paginate]); // paginate 쪽수 변경할 때마다 새로운 데이터 가지고 오게 의존성 추가
+  */
+
   return (
     <MainContainer>
       <Subtitle>찬반토론</Subtitle>
       <ProConDiscussionCardContainer>
-        {dummyData.posts.map((post) => (
+        {posts.map((post) => (
           <ProConDiscussionCard procondiscussionData={post} key={post.id} />
         ))}
       </ProConDiscussionCardContainer>
+      <Pagination
+        paginate={paginate}
+        setPaginate={setPaginate}
+        paginationInfo={paginationInfo}
+      />
     </MainContainer>
   );
 }


### PR DESCRIPTION
### 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요. -->
- #7 
- #34

### ✨개발 내용
<!-- 개발한 내용을 설명을 적어주세요 -->
- get 요청을 통해 데이터를 받아올 경우 응답으로 오는 pageInfo를 이용하여 이에 맞게 Pagination 컴포넌트를 수정하였습니다.

```tsx
function Pagination({
  currentPage,
  setPaginate,
  paginationInfo,
}: PaginationProps) {
  const { page, totalPage } = paginationInfo;
  const pageNumbers = Array.from({ length: totalPage }, (_, idx) => idx + 1);

  return (
    <PaginationContainer>
       ...생략
         <PageButton
        onClick={() =>
          currentPage=== 1 ? setPaginate(1) : setPaginate(page - 1)
        }
      >
        <IoIosArrowBack size={11} />
      </PageButton>
      {pageNumbers.map((num: number) => (
        <ButtonNav
          key={num}
          onClick={() => setPaginate(num)}
          isCurrentPage={num === page}
        >
          {num}
        </ButtonNav>
      ))}
       ...생략

```

### 👓 고민 사항

#### 😍 페이지네이션 사용

```tsx
  const [posts, setPosts] = useState(post초기값);
  const [paginate, setPaginate] = useState(1);
  const [paginationInfo, setPaginationInfo] = useState(응답받은 pageInfo);

  useEffect(() => {
    const fetchData = async () => {
      try {
        // params에 현재 page 쪽수(paginate), 보여질 게시물 개수인 limit 담기
        const res = await fetch(url).then((res) => res.json());
        const postData = res.data;
        const paginationData: PageInfo = res.pageInfo;
        
        // setPosts 만들어서
        setPosts(postData);
        // setPosts 만들어서
        setPaginationInfo(postData)
      } catch (e) {
        console.log(e)
      }
        
    };
  }, [paginate]); // paginate 쪽수 변경할 때마다 새로운 데이터 가지고 오게 의존성 추가

  return (
      ...생략
      <Pagination
        currentPage={paginate}
        setPaginate={setPaginate}
        paginationInfo={paginationInfo}
      />
      ...생략
  );
}
```

#### 📌Props로 넘겨줘야 할 것들
- currentPage
> 버튼을 눌렀을 때 페이지  쪽 수 이동을 위해 현재 페이지 쪽 수를 넘겨 주어야 합니다! 페이지네이션을 사용하는 함수 컴포넌트에서 `const [paginate, setPaginate] = useState(1);` 에서의 paginate입니다.

- setPaginate
> 페이지 이동을 위해 페이지네이션을 사용하는 함수 컴포넌트에서 해당 페이지 이동을 위해 setState() 함수를 넘겨 줍니다! 이는 페이지네이션을 사용하는 함수 컴포넌트의 `const [paginate, setPaginate] = useState(1);` 에서의 setPaginate입니다. 데이터를 가져오는 의존성으로 paginate를 추가해 놓으므로써 paginate가 변동 시, 새로운 쪽수의 응답 데이터를 받을 수 있을 것입니다!

- paginationInfo
> 처음 페이지네이션을 사용하는 함수 컴포넌트에서 get 요청으로 받아오는 페이지네이션 정보(총 쪽수, 총 게시물 수,  등)을 넘겨 주어야 합니다. 이 페이지네이션 정보는 페이지네이션 버튼을 몇 개를 만들 것인지, 맨처음과 맨끝에 도달했을 때 더 넘어가지 못하도록 설정하기 위해 사용됩니다.

🤔 이와 같이 응답으로 오는 pageInfo 데이터를 사용하여 페이지네이션 컴포넌트를 수정하였는데 어떠신가요?
