### PR TITLE
[Feature] Search Page 찬반토론 카드 컴포넌트 구현

### DIFF
--- a/src/components/Search/ProConDiscussionSearchCard.tsx
+++ b/src/components/Search/ProConDiscussionSearchCard.tsx
@@ -1,0 +1,74 @@
+import styled from 'styled-components';
+import { Link } from 'react-router-dom';
+import { Card } from '../UI/Card/Card';
+import { Flex, ColFlex } from '../../styles/shared';
+
+function ProConDiscussionSearchCard() {
+  const proRate = '45%';
+  const conRate = '55%';
+
+  return (
+    <CardContainer to="/search">
+      <DiscussionTitle>다나카는 일본인인가?</DiscussionTitle>
+      <ProConBlockBox>
+        <ProConBlock isPro>
+          <ProConRateText>
+            찬성
+            <br />
+            {proRate}
+          </ProConRateText>
+        </ProConBlock>
+        <ProConBlock isPro={false}>
+          <ProConRateText>
+            반대
+            <br />
+            {conRate}
+          </ProConRateText>
+        </ProConBlock>
+      </ProConBlockBox>
+    </CardContainer>
+  );
+}
+
+const CardContainer = styled(Link)`
+  ${Card}
+  ${ColFlex}
+  width: 320px;
+  height: 275px;
+  border: none;
+  border-radius: 0;
+  margin: 0 20px 50px;
+`;
+
+const DiscussionTitle = styled.h3`
+  ${Flex}
+  flex: 2;
+  font-weight: 700;
+  font-size: var(--font-size-m);
+`;
+
+const ProConBlockBox = styled.div`
+  ${Flex}
+  flex: 8;
+`;
+
+const ProConBlock = styled.div<{ isPro: boolean }>`
+  ${Flex}
+  flex: 1;
+  height: 100%;
+
+  background-color: ${({ isPro }) =>
+    isPro ? 'var(--color-primary-mint)' : 'var(--color-primary-pink)'};
+
+  &:hover {
+    filter: brightness(0.97);
+  }
+`;
+
+const ProConRateText = styled.p`
+  color: var(--white);
+  font-weight: 700;
+  line-height: 1.5;
+`;
+
+export default ProConDiscussionSearchCard;

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -1,7 +1,22 @@
-import React from 'react';
+import styled from 'styled-components';
+import ProConDiscussionSearchCard from '../components/Search/ProConDiscussionSearchCard';
+import MainContainer from '../styles/layout';
+import { Flex } from '../styles/shared';
 
 function SearchPage() {
-  return <div>SearchPage</div>;
+  return (
+    <MainContainer>
+      <ProConDiscussionSearchCardContainer>
+        <ProConDiscussionSearchCard />
+        <ProConDiscussionSearchCard />
+        <ProConDiscussionSearchCard />
+      </ProConDiscussionSearchCardContainer>
+    </MainContainer>
+  );
 }
+
+const ProConDiscussionSearchCardContainer = styled.section`
+  ${Flex}
+`;
 
 export default SearchPage;


### PR DESCRIPTION
### 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요. -->
- #77

### ✨개발 내용
<!-- 개발한 내용을 설명을 적어주세요 -->
- 통합검색 페이지 내의 찬반토론 검색 카드 컴포넌트 구현
#### src/components/Search/ProConDiscussionSearchCard.tsx
```tsx
    <CardContainer to="/search">
      <DiscussionTitle>다나카는 일본인인가?</DiscussionTitle>
      <ProConBlockBox>
        <ProConBlock isPro>
          <ProConRateText>
            찬성
            <br />
            {proRate}
          </ProConRateText>
        </ProConBlock>
        <ProConBlock isPro={false}>
          <ProConRateText>
            반대
            <br />
            {conRate}
          </ProConRateText>
        </ProConBlock>
      </ProConBlockBox>
    </CardContainer>
```

### 📸 스크린샷
<!-- 스크린샷이 필요한 과제면 스크린샷을 첨부해주세요 -->
`+`  호버 시, 배경색상보다 살짝 어두워집니다.
![image](https://user-images.githubusercontent.com/116181346/234609199-d60cb374-f402-483b-96e4-de6dcbc4c391.png)

### 👓 고민 사항
1. 스타일드 컴포넌트 네이밍을 적절하게 했는지 모르겠네요 😅 더 좋은 네이밍이 있다면 추천해 주세요!
2. 찬성과 반대 각 블럭을 눌렀을 때 사용자의 편의성을 위해 투표가 가능하게 하도록 하자고 얘기를 했던 것 같은데 제 기억이 맞나요? 오래전이라 기억이 가물가물 하네요 ㅎㅎ