### PR TITLE
[Feature] 독서토론 & 찬반토론 기능 구현

### DIFF
--- a/src/components/ProConDiscussion/ProConDiscussionCard.tsx
+++ b/src/components/ProConDiscussion/ProConDiscussionCard.tsx
@@ -6,8 +6,8 @@ import UserProfile from '../UI/UserProfile/UserProfile';
 import ProConLeaderTag from '../UI/Tag/ProConLeaderTag';
 import ProgressBar from '../UI/ProgressBar/ProgressBar';
 import {
-  Flex,
-  ColFlex,
+  flex,
+  colFlex,
   profileBoxCSS,
   truncateTextCSS,
 } from '../../styles/shared';
@@ -25,11 +25,11 @@ const noneImageUrl =
 function ProConDiscussionCard({
   procondiscussionData,
 }: ProConDiscussionCardProps) {
-  const proLeader = procondiscussionData.agreeUser;
-  const conLeader = procondiscussionData.disagreeUser;
-  const proCount = procondiscussionData.agreeCount;
+  const proLeader = procondiscussionData.proLeader?.username;
+  const conLeader = procondiscussionData.conLeader?.username;
+  const { proCount } = procondiscussionData;
   const proRate = String(
-    (proCount / (proCount + procondiscussionData.disagreeCount)) * 100,
+    (proCount / (proCount + procondiscussionData.conCount)) * 100,
   );
 
   return (
@@ -75,8 +75,8 @@ function ProConDiscussionCard({
 
 const CardContainer = styled(Link)`
   ${Card};
-  ${Flex}
-  gap: 50px;
+  ${flex}
+  gap: 20px;
   width: 970px;
   height: 250px;
   padding: 30px;
@@ -97,14 +97,16 @@ const Content = styled.p`
 
 const ProfileBox = styled.div`
   ${profileBoxCSS}
+  flex: 2;
   height: 100%;
   padding-top: 10px;
   justify-content: flex-start;
 `;
 
 const DiscussionInfoWrap = styled.div`
-  ${ColFlex};
-  gap: 20px;
+  ${colFlex};
+  flex: 7;
+  gap: 30px;
   align-items: center;
 `;
 

--- a/src/pages/BookDiscussionPage.tsx
+++ b/src/pages/BookDiscussionPage.tsx
@@ -1,45 +1,64 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import styled from 'styled-components';
 import MainContainer from '../styles/layout';
 import { BookDiscussionInfo, PageInfo } from '../types';
-import Pagination from '../components/UI/Pagination/Pagination';
 import { discussionCardContainerCSS } from '../styles/shared';
+import Pagination from '../components/UI/Pagination/Pagination';
 import BookDiscussionCard from '../components/BookDiscussion/BookDiscussionCard';
-import BOOKDISCUSSION_DUMMY from '../components/BookDiscussion/BOOKDISCUSSION_DUMMY';
+
+interface GetBookDiscussion {
+  pageInfo: PageInfo;
+  posts: BookDiscussionInfo[];
+}
 
 function BookDiscussion() {
-  const [posts] = useState<BookDiscussionInfo[]>(BOOKDISCUSSION_DUMMY.data);
+  const { VITE_API_URL } = import.meta.env;
+  const [posts, setPosts] = useState<BookDiscussionInfo[]>([]);
   const [paginate, setPaginate] = useState(1);
-  const [paginationInfo] = useState<PageInfo>(BOOKDISCUSSION_DUMMY.pageInfo);
+  const [paginationInfo, setPaginationInfo] = useState<PageInfo>({
+    page: 1,
+    totalPage: 1,
+    totalCount: 1,
+    currentCount: 1,
+  });
 
-  /* 9개씩 가지고 옴
+  // apis로 뺄 예정
+  const getBookDiscussion = async (
+    page: number,
+  ): Promise<GetBookDiscussion> => {
+    const url = `${VITE_API_URL}book-discussions?page=${page}&limit=9`;
+
+    const response = await fetch(url, {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json',
+        'ngrok-skip-browser-warning': '12',
+      },
+    });
+
+    const data = await response.json();
+    return data;
+  };
+
   useEffect(() => {
-    const fetchData = async () => {
-      try {
-        // params에 현재 page 쪽수, 보여질 게시물 개수인 limit 담기
-        const res = await fetch('').then((res) => res.json());
-        const postData = res.data;
-        const paginationData: PageInfo = res.pageInfo;
-        
-        // setPosts 만들어서
-        setPosts(postData);
-        // setPosts 만들어서
-        setPaginationInfo(postData)
-      } catch (e) {
-        console.log(e)
-      }
-        
-    };
-  }, [paginate]); // paginate 쪽수 변경할 때마다 새로운 데이터 가지고 오게 의존성 추가
-  */
+    try {
+      getBookDiscussion(paginate).then((res) => {
+        setPosts(res.posts);
+        setPaginationInfo(res.pageInfo);
+      });
+    } catch (e) {
+      console.log(e);
+    }
+  }, [paginate]);
 
   return (
     <MainContainer>
       <Subtitle>독서토론</Subtitle>
       <BookDiscussionCardContainer>
-        {posts.map((post) => (
-          <BookDiscussionCard bookDiscussionData={post} key={post.id} />
-        ))}
+        {posts &&
+          posts.map((post) => (
+            <BookDiscussionCard bookDiscussionData={post} key={post.id} />
+          ))}
       </BookDiscussionCardContainer>
       <Pagination
         currentPage={paginate}

--- a/src/pages/ProConDiscussionPage.tsx
+++ b/src/pages/ProConDiscussionPage.tsx
@@ -24,7 +24,7 @@ function ProConDiscussion() {
   });
 
   // apis로 뺄 예정
-  const getBookDiscussion = async (
+  const getProConDiscussion = async (
     page: number,
   ): Promise<GetProConDiscussion> => {
     const url = `${VITE_API_URL}pro-con-discussions?page=${page}&limit=4`;
@@ -43,7 +43,7 @@ function ProConDiscussion() {
 
   useEffect(() => {
     try {
-      getBookDiscussion(paginate).then((res) => {
+      getProConDiscussion(paginate).then((res) => {
         setPosts(res.posts);
         setPaginationInfo(res.pageInfo);
       });

--- a/src/pages/ProConDiscussionPage.tsx
+++ b/src/pages/ProConDiscussionPage.tsx
@@ -1,40 +1,56 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import styled from 'styled-components';
 import MainContainer from '../styles/layout';
-import { ColFlex } from '../styles/shared';
+import { colFlex } from '../styles/shared';
 import { Subtitle } from './BookDiscussionPage';
-import { ProConDiscussionInfo, PageInfo } from '../types';
+import { PageInfo, ProConDiscussionInfo } from '../types';
 import Pagination from '../components/UI/Pagination/Pagination';
 import ProConDiscussionCard from '../components/ProConDiscussion/ProConDiscussionCard';
-import PROCONDISCUSSION_DUMMY from '../components/ProConDiscussion/PROCONDISCUSSION_DUMMY';
+
+interface GetProConDiscussion {
+  pageInfo: PageInfo;
+  posts: ProConDiscussionInfo[];
+}
 
 function ProConDiscussion() {
-  const [posts] = useState<ProConDiscussionInfo[]>(
-    PROCONDISCUSSION_DUMMY.posts,
-  );
+  const { VITE_API_URL } = import.meta.env;
+  const [posts, setPosts] = useState<ProConDiscussionInfo[]>([]);
   const [paginate, setPaginate] = useState(1);
-  const [paginationInfo] = useState<PageInfo>(PROCONDISCUSSION_DUMMY.pageInfo);
+  const [paginationInfo, setPaginationInfo] = useState<PageInfo>({
+    page: 1,
+    totalPage: 1,
+    totalCount: 1,
+    currentCount: 1,
+  });
 
-  /* 4개씩 가지고 옴
+  // apis로 뺄 예정
+  const getBookDiscussion = async (
+    page: number,
+  ): Promise<GetProConDiscussion> => {
+    const url = `${VITE_API_URL}pro-con-discussions?page=${page}&limit=4`;
+
+    const response = await fetch(url, {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json',
+        'ngrok-skip-browser-warning': '12',
+      },
+    });
+
+    const data = await response.json();
+    return data;
+  };
+
   useEffect(() => {
-    const fetchData = async () => {
-      try {
-        // params에 현재 page 쪽수, 보여질 게시물 개수인 limit 담기
-        const res = await fetch('').then((res) => res.json());
-        const postData = res.data;
-        const paginationData: PageInfo = res.pageInfo;
-        
-        // setPosts 만들어서
-        setPosts(postData);
-        // setPosts 만들어서
-        setPaginationInfo(postData)
-      } catch (e) {
-        console.log(e)
-      }
-        
-    };
-  }, [paginate]); // paginate 쪽수 변경할 때마다 새로운 데이터 가지고 오게 의존성 추가
-  */
+    try {
+      getBookDiscussion(paginate).then((res) => {
+        setPosts(res.posts);
+        setPaginationInfo(res.pageInfo);
+      });
+    } catch (e) {
+      console.log(e);
+    }
+  }, [paginate]);
 
   return (
     <MainContainer>
@@ -54,7 +70,7 @@ function ProConDiscussion() {
 }
 
 const ProConDiscussionCardContainer = styled.section`
-  ${ColFlex}
+  ${colFlex}
   align-items: center;
   margin-bottom: 50px;
 `;

--- a/src/types/Book.type.ts
+++ b/src/types/Book.type.ts
@@ -1,30 +1,7 @@
 // 외부 API의 검색 결과 데이터 타입
-export interface InterparkBookSearchResult {
-  totalResults: number;
-  startIndex: number;
-  itemsPerPage: number;
-  items: InterparkBookSearchItem[];
-}
-
-export interface InterparkBookSearchItem {
-  title: string;
-  author: string;
-  publisher: string;
-  pubDate: string;
-  coverSmallUrl: string;
-  coverLargeUrl: string;
-  description: string;
-  isbn: string;
-  categoryCode: string;
-  categoryName: string;
-  priceSales: number;
-  priceStandard: number;
-  priceMileage: number;
-  saleStatus: string;
-  stockStatus: string;
-}
 
 export interface Book {
+  id: number;
   isbn: number;
   title: string;
   author: string;
@@ -35,4 +12,59 @@ export interface Book {
   publisher: string;
   pubdate: string;
   category: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface AladinBookSearchResult {
+  version: string;
+  logo: string;
+  title: string;
+  link: string;
+  pubDate: string;
+  totalResults: number;
+  startIndex: number;
+  itemsPerPage: number;
+  query: string;
+  searchCategoryId: number;
+  searchCategoryName: string;
+  item: AladinBookSearchItem[];
+}
+
+export interface AladinBookSearchItem {
+  title: string;
+  link: string;
+  author: string;
+  pubDate: string;
+  description: string;
+  isbn: string;
+  isbn13: string;
+  itemId: number;
+  priceSales: number;
+  priceStandard: number;
+  mallType: string;
+  stockStatus: string;
+  mileage: number;
+  cover: string;
+  categoryId: number;
+  categoryName: string;
+  publisher: string;
+  salesPoint: number;
+  adult: false;
+  fixedPrice: true;
+  customerReviewRank: number;
+  seriesInfo?: SeriesInfo;
+  subInfo: SubInfo | never;
+}
+
+interface SeriesInfo {
+  seriesId: number;
+  seriesLink: string;
+  seriesName: string;
+}
+
+interface SubInfo {
+  subTitle: string;
+  originalTitle: string;
+  itemPage: number;
 }

--- a/src/types/BookDisscussionPost.type.ts
+++ b/src/types/BookDisscussionPost.type.ts
@@ -1,9 +1,14 @@
+import { Book } from './Book.type';
+
 export interface BookDiscussionInfo {
   id: string;
   author: string;
   title: string;
   content: string;
-  like: number;
+  likeCount: number;
   createdAt: string;
   updatedAt: string;
+  postLikedByUser: boolean;
+  views: number;
+  book?: Book;
 }

--- a/src/types/ProConDiscussionPost.type.ts
+++ b/src/types/ProConDiscussionPost.type.ts
@@ -4,11 +4,15 @@ export interface ProConDiscussionInfo {
   title: string;
   content: string;
   views: number;
-  thumbup: number;
   createdAt: string;
   updatedAt: string;
-  agreeCount: number;
-  disagreeCount: number;
-  agreeUser: string;
-  disagreeUser: null | string;
+  proCount: number;
+  conCount: number;
+  proLeader: ProConLeader | null;
+  conLeader: ProConLeader | null;
+}
+
+export interface ProConLeader {
+  username: string;
+  avatarUrl: string | null;
 }


### PR DESCRIPTION
### 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요. -->
- #31 
- #45
- #99 
- #100

### ✨개발 내용
<!-- 개발한 내용을 설명을 적어주세요 -->
- 알라딘 open API 요청으로 오는 응답에 대한 Type 생성
- 독서토론 게시물 GET API 요청
- 찬반토론 게시물 GET API 요청
- 독서토론 & 찬반토론 응답 데이터에 맞게 타입 수정

#### src/pages/BookDiscussionPage.tsx
```tsx
const getBookDiscussion = async (
    page: number,
  ): Promise<GetBookDiscussion> => {
    const url = `${VITE_API_URL}book-discussions?page=${page}&limit=9`;

    const response = await fetch(url, {
      method: 'GET',
      headers: {
        'Content-Type': 'application/json',
        'ngrok-skip-browser-warning': '12',
      },
    });

    const data = await response.json();
    return data;
  };
```

#### src/pages/ProConDiscussionPage.tsx
```tsx
 const getProConDiscussion = async (
    page: number,
  ): Promise<GetProConDiscussion> => {
    const url = `${VITE_API_URL}pro-con-discussions?page=${page}&limit=4`;

    const response = await fetch(url, {
      method: 'GET',
      headers: {
        'Content-Type': 'application/json',
        'ngrok-skip-browser-warning': '12',
      },
    });

    const data = await response.json();
    return data;
  };
```

### 👓 고민 사항
- 사용하려고 했던 open API가 인터파크 => 알라딘으로 변경되어 백엔드에서 응답 데이터 양식이 변동되어 수정되면 이에 맞게 또 수정이 필요할 것 같습니다!
- api 요청을 하는 함수를 apis 폴더 아래에 파일을 생성하기로 하였으나, 정수님께서 로딩과 에러 처리와 같은 중복되는 로직을 방지하고자 hook을 사용해 보자고 하셔서 일단은 page 컴포넌트 내에 api 요청 로직을 작성하였습니다! 추후에 따로 빼도록 하겠습니다!
