### PR TITLE
[Feature] 로그인 상태 유지 기능

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,20 +1,10 @@
-import { useEffect } from 'react';
 import { RouterProvider } from 'react-router-dom';
 import { RecoilRoot } from 'recoil';
-import logout from './utils/auth/logout';
-
+import useLoggedIn from './hooks/useLoggedIn';
 import route from './Routes';
 
 function App() {
-  useEffect(() => {
-    const isStayLoggedIn =
-      localStorage.getItem('stayLoggedIn') === 'true' || false;
-    return () => {
-      if (!isStayLoggedIn) {
-        logout();
-      }
-    };
-  }, []);
+  useLoggedIn();
 
   return (
     <RecoilRoot>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,9 +1,21 @@
+import { useEffect } from 'react';
 import { RouterProvider } from 'react-router-dom';
 import { RecoilRoot } from 'recoil';
+import logout from './utils/auth/logout';
 
 import route from './Routes';
 
 function App() {
+  useEffect(() => {
+    const isStayLoggedIn =
+      localStorage.getItem('stayLoggedIn') === 'true' || false;
+    return () => {
+      if (!isStayLoggedIn) {
+        logout();
+      }
+    };
+  }, []);
+
   return (
     <RecoilRoot>
       <RouterProvider router={route} />

--- a/src/Routes/route.tsx
+++ b/src/Routes/route.tsx
@@ -1,4 +1,5 @@
 import { Outlet } from 'react-router-dom';
+
 import GlobalStyle from '../styles/GlobalStyle';
 import Header from '../components/Layout/Header/Header';
 import Footer from '../components/Layout/Footer/Footer';

--- a/src/components/LoginSignupForm/Form.tsx
+++ b/src/components/LoginSignupForm/Form.tsx
@@ -2,7 +2,7 @@ import React, { useId, useState } from 'react';
 import styled from 'styled-components';
 import { Form, useNavigate } from 'react-router-dom';
 import Button from '../UI/Button/Button';
-import { colFlex } from '../../styles/shared';
+import { colFlex, rowFlex } from '../../styles/shared';
 
 interface FormProps {
   pathname: string;
@@ -16,6 +16,9 @@ function FormBox({ pathname, onSubmit, displayError }: FormProps) {
   const [checkPassword, setCheckPassword] = useState('');
   const isLogin = pathname.includes('login');
   const navigate = useNavigate();
+  const [isStayLoggedIn, setIsStayLoggedIn] = useState(
+    localStorage.getItem('stayLoggedIn') === 'true' || false,
+  );
 
   const emailId = useId();
   const passwordId = useId();
@@ -44,6 +47,11 @@ function FormBox({ pathname, onSubmit, displayError }: FormProps) {
   const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     onSubmit(email, password, checkPassword);
+  };
+
+  const handleStayLoggedIn = () => {
+    setIsStayLoggedIn((prev) => !prev);
+    localStorage.setItem('stayLoggedIn', String(!isStayLoggedIn));
   };
 
   return (
@@ -95,10 +103,21 @@ function FormBox({ pathname, onSubmit, displayError }: FormProps) {
             <Input
               type="password"
               name="checkPassword"
-              value={checkPassword}
               placeholder="비밀번호를 확인하세요"
               onChange={onChange}
             />
+          )}
+          {isLogin && (
+            <StayLoggedInContainer>
+              <Input
+                type="checkbox"
+                name="stayLoggedIn"
+                id="stayLoggedIn"
+                onChange={handleStayLoggedIn}
+                checked={isStayLoggedIn}
+              />
+              <label htmlFor="stayLoggedIn">로그인 상태 유지</label>
+            </StayLoggedInContainer>
           )}
 
           <Button
@@ -124,6 +143,15 @@ function FormBox({ pathname, onSubmit, displayError }: FormProps) {
     </FormContainer>
   );
 }
+
+const StayLoggedInContainer = styled.section`
+  ${rowFlex}
+  align-items: center;
+  input {
+    margin-bottom: 3px;
+    margin-right: 5px;
+  }
+`;
 
 const DisplayErrorWrraper = styled.ul`
   ${colFlex}

--- a/src/hooks/useLoggedIn.ts
+++ b/src/hooks/useLoggedIn.ts
@@ -1,0 +1,16 @@
+import { useEffect } from 'react';
+import logout from '../utils/auth/logout';
+
+function useLoggedIn() {
+  useEffect(() => {
+    const isStayLoggedIn =
+      localStorage.getItem('stayLoggedIn') === 'true' || false;
+    return () => {
+      if (!isStayLoggedIn) {
+        logout();
+      }
+    };
+  }, []);
+}
+
+export default useLoggedIn;

--- a/src/utils/auth/logout.ts
+++ b/src/utils/auth/logout.ts
@@ -1,0 +1,7 @@
+function logout() {
+  console.log('실행');
+  localStorage.removeItem('recoil-user');
+  localStorage.removeItem('recoil-jwt');
+}
+
+export default logout;

--- a/src/utils/auth/logout.ts
+++ b/src/utils/auth/logout.ts
@@ -1,6 +1,7 @@
 function logout() {
   localStorage.removeItem('recoil-user');
   localStorage.removeItem('recoil-jwt');
+  localStorage.setItem('stayLoggedIn', 'false');
 }
 
 export default logout;

--- a/src/utils/auth/logout.ts
+++ b/src/utils/auth/logout.ts
@@ -1,5 +1,4 @@
 function logout() {
-  console.log('실행');
   localStorage.removeItem('recoil-user');
   localStorage.removeItem('recoil-jwt');
 }


### PR DESCRIPTION
### 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요. -->
- #88 

### ✨개발 내용
<!-- 개발한 내용을 설명을 적어주세요 -->
로그인 상태를 유지하는 것과 끄는 것을 선택하는 기능이 있으면 좋겠다는 의견을 받아 개발했습니다.

### 📸 스크린샷(선택)
<!-- 스크린샷이 필요한 과제면 스크린샷을 첨부해주세요 -->
<img width="568" alt="image" src="https://github.com/jumak-dev/imojumo/assets/74353528/0cae8663-a22f-47ac-ae3d-c4a583dc0273">

### 👓 고민 사항(선택)
처음에는 route에 useEffect를 이용해 기능을 구현하려고 했는데 Root, Home, LoginRoot로 나눠져 있어 App에서 구현하기로 결정했습니다.

App에서 구현할 경우 RecoilRoot 밖이어서 recoil hooks를 사용 못하므로 삭제 기능을 구현할 때 
localStorage에서 직접 지워줬습니다.

```javascript
function logout() {
  localStorage.removeItem('recoil-user');
  localStorage.removeItem('recoil-jwt');
}

export default logout;
```
때문에 로그인 유지 여부를 관리하는 atom을 새로 만들려고 하다가 필요 없어져서 localStorage만을 사용하여 구현했습니다.


### 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
<!-- 참고할 사항이 있다면 적어주세요 -->
