### PR TITLE
[Feature] promise 상태 타입 생성, APIError 타입 추출, onError 타입 적용

### DIFF
--- a/src/apis/api.ts
+++ b/src/apis/api.ts
@@ -1,8 +1,4 @@
-interface APIError {
-  status: number;
-  error: string;
-  message: string[];
-}
+import { APIError } from '../types';
 
 interface requestType {
   url: string;

--- a/src/constants/Promise.ts
+++ b/src/constants/Promise.ts
@@ -1,0 +1,8 @@
+const PROMISE_STATUS = {
+  IDLE: 'idle',
+  PENDING: 'pending',
+  FULFILLED: 'fulfilled',
+  ERROR: 'error',
+} as const;
+
+export default PROMISE_STATUS;

--- a/src/hooks/useMutate.ts
+++ b/src/hooks/useMutate.ts
@@ -69,6 +69,7 @@ function useMutate<I, T>({
     error,
     data: result,
     mutate,
+    setData: setResult,
   };
 }
 

--- a/src/hooks/useMutate.ts
+++ b/src/hooks/useMutate.ts
@@ -1,11 +1,13 @@
 import { useState } from 'react';
+import { APIError, PromiseStatusType } from '../types';
+import PROMISE_STATUS from '../constants/Promise';
 
 interface UseMuateProps<I, T> {
   fetchFn: (args: I) => Promise<T>;
   isSuspense?: boolean;
   isErrorBoundary?: boolean;
   onSuccess?: (data: T | null) => void;
-  onError?: (error: unknown) => void;
+  onError?: (error: Error | APIError) => void;
   onSettled?: (data: T | null, error: unknown) => void;
 }
 
@@ -18,14 +20,12 @@ function useMutate<I, T>({
   onSettled,
 }: UseMuateProps<I, T>) {
   const [promise, setPromise] = useState<Promise<void>>();
-  const [status, setStatus] = useState<'pending' | 'fulfilled' | 'error'>(
-    'pending',
-  );
+  const [status, setStatus] = useState<PromiseStatusType>(PROMISE_STATUS.IDLE);
   const [result, setResult] = useState<T>();
   const [error, setError] = useState<Error>();
 
   const resolvePromise = (promiseResult: T) => {
-    setStatus('fulfilled');
+    setStatus(PROMISE_STATUS.FULFILLED);
     setResult(promiseResult);
 
     if (onSuccess && typeof onSuccess === 'function') {
@@ -38,7 +38,7 @@ function useMutate<I, T>({
   };
 
   const rejectPromise = (promiseError: Error) => {
-    setStatus('error');
+    setStatus(PROMISE_STATUS.PENDING);
     setError(promiseError);
 
     if (onError && typeof onError === 'function') {
@@ -51,20 +51,21 @@ function useMutate<I, T>({
   };
 
   const mutate = async (arg: I) => {
-    setStatus('pending');
+    setStatus(PROMISE_STATUS.PENDING);
     setPromise(fetchFn(arg).then(resolvePromise, rejectPromise));
+    return promise;
   };
 
-  if (isSuspense && status === 'pending' && promise) {
+  if (isSuspense && status === PROMISE_STATUS.PENDING && promise) {
     throw promise;
   }
 
-  if (isErrorBoundary && status === 'error') {
+  if (isErrorBoundary && status === PROMISE_STATUS.ERROR) {
     throw error;
   }
 
   return {
-    isLoading: status === 'pending',
+    isLoading: status === PROMISE_STATUS.PENDING,
     error,
     data: result,
     mutate,

--- a/src/hooks/useQuery.ts
+++ b/src/hooks/useQuery.ts
@@ -75,6 +75,7 @@ function useQuery<I, T>({
     error,
     data: result,
     refetch: fetch,
+    setData: setResult,
   };
 }
 

--- a/src/types/Book.type.ts
+++ b/src/types/Book.type.ts
@@ -13,6 +13,7 @@ export interface Book {
   pubDate: string;
   createdAt?: string;
   updatedAt?: string;
+  category?: string;
 }
 
 export interface AladinBookSearchResult {

--- a/src/types/Error.type.ts
+++ b/src/types/Error.type.ts
@@ -1,0 +1,5 @@
+export interface APIError {
+  status: number;
+  error: string;
+  message: string[];
+}

--- a/src/types/Promise.type.ts
+++ b/src/types/Promise.type.ts
@@ -1,0 +1,7 @@
+import PROMISE_STATUS from '../constants/Promise';
+
+export type PromiseStatusType =
+  | typeof PROMISE_STATUS.IDLE
+  | typeof PROMISE_STATUS.PENDING
+  | typeof PROMISE_STATUS.FULFILLED
+  | typeof PROMISE_STATUS.ERROR;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -4,3 +4,5 @@ export * from './BookDiscussionPost.type';
 export * from './UseSearchAladinBook.type';
 export * from './ProConDiscussionPost.type';
 export * from './Comment.type';
+export * from './Promise.type';
+export * from './Error.type';


### PR DESCRIPTION
### 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요. -->
- #110 

### ✨개발 내용
<!-- 개발한 내용을 설명을 적어주세요 -->
- 공통 Fetch 관련 수정사항
  - promise status 타입 생성 및 적용
    - PROMISE_STATUS 상수 생성
      ```ts
      const PROMISE_STATUS = {
        IDLE: 'idle',
        PENDING: 'pending',
        FULFILLED: 'fulfilled',
        ERROR: 'error',
      } as const;
      ```
    - PromiseStatusType 타입 생성
       ```ts
       export type PromiseStatusType =
        | typeof PROMISE_STATUS.IDLE
        | typeof PROMISE_STATUS.PENDING
        | typeof PROMISE_STATUS.FULFILLED
        | typeof PROMISE_STATUS.ERROR;
       ```
  - APIError 타입 위치 apis에서 types폴더 위치 변경
  - Error 타입적용


### 📸 스크린샷(선택)
<!-- 스크린샷이 필요한 과제면 스크린샷을 첨부해주세요 -->
- 이전 PR은 조금 내용이 길었어서 다시 예시를 작성해봤습니다.fetch를 선언형으로 사용했을때와 안했을때 어떻게 달라지는지 예시입니다
  - 사용전
  ```tsx
  function ProConDiscussionForm() {
    const [loading, setLoading] = useState(false);
    
    const handleFormSubmit = async (
      event:
        | React.MouseEvent<HTMLButtonElement>
        | React.FormEvent<HTMLFormElement>,
    ) => {
      event.preventDefault();
  
      try {
        setLoading(true);
        const data = await createProConDiscussion({ title, content, isPro, token });
        
        if (data) {
           navigate(`/pro-con-discussion/${data.id}`);
        }
      } catch  (error) {
        console.log(`err: ${error.message[0]}`);
      } finally {
        setLoading(false);
      }
    };
  }
  ```
  - 사용후
  ```tsx
  function ProConDiscussionForm() {
    const { mutate, isLoading } = useCreateProConDiscussion({
      onSuccess: (data) => {
        navigate(`/pro-con-discussion/${data.id}`);
      },
      onError: (error) => {
        console.log(`err: ${error.message[0]}`);
      },
    });
  
    const handleFormSubmit = async (
      event:
        | React.MouseEvent<HTMLButtonElement>
        | React.FormEvent<HTMLFormElement>,
    ) => {
      event.preventDefault();
  
      await mutate({ title, content, isPro, token });
    };
  }
  ```

- 선언형으로 했을때 가장 큰 장점은 가독성이라고 생각됩니다.
- 복잡한 try catch, if는  코드를 읽다보면 개발자가 어느 상황에 어떤 코드가 실행하는지 파악하기 난해해질때가 있습니다.
- 하지만 선언형은 선언부에 모든게 추상화되어 있기 때문에 한눈에 전체 코드를 파악할 수 있습니다.
- 위의 예시처럼, ProConDiscussion를 생성(mutate)하는데 성공(onSuccess)하면 navigate하고 실패(onError)하면 console.log 를 찍는구나를 바로 파악할 수 있습니다.
- 단점은 컴포넌트에서 가독성은 좋아지지만 구현부(fetch 구현)가 다소 복잡해서 내부 동작을 이해하기 어렵다느껴질 수도 있고 보일러플레이트 코드를 작성해야해서 오히려 귀찮게 느껴질 수 있습니다. 

**이번에 기존 fetch로 구현한걸 useQuery 방식으로 수정해보며 어떤 코드가 더 나은지 고민해보면 좋을거 같습니다~**

참고 
- [선언형 VS 명령형](https://yeongseungjeong.tistory.com/37)
- [선언형 VS 명령형, 리액트가 선언형인 이유](https://velog.io/@nemo/%EC%84%A0%EC%96%B8%ED%98%95-%EB%AA%85%EB%A0%B9%ED%98%95)


### 👓 고민 사항(선택)
- 지금 useQuery나 useMutate hooks가 data(fetct 결과) 상태를 내부에서만 관리하고 있습니다. 
- 그런데, 현재 @Paksubeen (수빈)님의 토론 상세에서 새로운 댓글에 대해서 data를 부분 업데이트하는 상황이 고려하지 못하고 구현되었습니다.
  ```tsx
  const data = useGetDetail(); // data 변수만 나옴
  const { mutate } = useCommentMutate(); // data 변수만 나옴
  
  handleCreateComment = () => {
    mutate({comment}); // 신규 데이터
    // Todo: mutate의 결과를 data에 업데이트
    // setData가 없어서 data에 업데이트를 못함 
  }
  
  ```

- 이런 상황이 발생할거 같은데, setData를 hooks에 반환값으로 넘기는게 좋을까요?
- 아니면, contextAPI 등과 같이 전역 상태에 관리하는게 좋을까요? (react-query의 전역 컨셉)

### 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
<!-- 참고할 사항이 있다면 적어주세요 -->
