### PR TITLE
[Refactor] 찬반/독서 토론 상세에서 fetch -> 커스텀 훅 방식 적용

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -48,6 +48,9 @@ module.exports = {
       },
     ],
   },
+  globals: {
+    RequestInit: 'readonly',
+  },
   settings: {
     'import/resolver': {
       node: {

--- a/src/apis/api.ts
+++ b/src/apis/api.ts
@@ -2,11 +2,16 @@ import { APIError } from '../types';
 
 interface requestType {
   url: string;
-  options?: any;
+  options?: RequestInit;
 }
 
 async function request({ url, options }: requestType): Promise<any> {
   const response = await fetch(url, options);
+
+  if (response.status === 204) {
+    return response;
+  }
+
   const responseJson = await response.json();
 
   if (!response.ok) {

--- a/src/apis/bookDiscussion.ts
+++ b/src/apis/bookDiscussion.ts
@@ -1,4 +1,8 @@
-import { BookDiscussionDetail, GetBookDiscussionDetailType } from '../types';
+import {
+  BookDiscussionDetail,
+  DeleteBookDiscussionType,
+  GetBookDiscussionDetailType,
+} from '../types';
 import request from './api';
 
 const { VITE_API_URL } = import.meta.env;
@@ -21,62 +25,50 @@ export async function getBookDiscussion({
   return response;
 }
 
-export async function deleteBookDiscussion(id: number, token: string) {
-  try {
-    const response = await fetch(`${VITE_API_URL}/book-discussions/${id}`, {
+export async function deleteBookDiscussion({
+  id,
+  token,
+}: DeleteBookDiscussionType) {
+  const response = await request({
+    url: `${VITE_API_URL}/book-discussions/${id}`,
+    options: {
       method: 'DELETE',
       headers: {
         'Content-Type': 'application/json',
         Authorization: `${token}`,
       },
-    });
+    },
+  });
 
-    if (!response.ok) {
-      const error = await response.json();
-      throw new Error(error.message);
-    }
-  } catch (error) {
-    console.log(error);
-    throw error;
-  }
+  return response;
 }
 
 export async function likeBookDiscussion(id: number, token: string) {
-  try {
-    const response = await fetch(`${VITE_API_URL}/likes/${id}`, {
+  const response = await request({
+    url: `${VITE_API_URL}/likes/${id}`,
+    options: {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
         Authorization: `${token}`,
       },
-    });
+    },
+  });
 
-    if (!response.ok) {
-      const error = await response.json();
-      throw new Error(error.message);
-    }
-  } catch (error) {
-    console.error(error);
-    throw error;
-  }
+  return response;
 }
 
 export async function unlikeBookDiscussion(id: number, token: string) {
-  try {
-    const response = await fetch(`${VITE_API_URL}/likes/${id}`, {
+  const response = await request({
+    url: `${VITE_API_URL}/likes/${id}`,
+    options: {
       method: 'DELETE',
       headers: {
         'Content-Type': 'application/json',
         Authorization: `${token}`,
       },
-    });
+    },
+  });
 
-    if (!response.ok) {
-      const error = await response.json();
-      throw new Error(error.message);
-    }
-  } catch (error) {
-    console.error(error);
-    throw error;
-  }
+  return response;
 }

--- a/src/apis/imojumo/proConDiscussions.ts
+++ b/src/apis/imojumo/proConDiscussions.ts
@@ -22,7 +22,6 @@ export async function createProConDiscussion({
         'Content-Type': 'application/json',
         Authorization: `${token}`,
       },
-      credentials: 'include',
       body: JSON.stringify({
         title,
         content,
@@ -85,7 +84,6 @@ export async function updateProConDiscussion({
         'Content-Type': 'application/json',
         Authorization: `${token}`,
       },
-      credentials: 'include',
       body: JSON.stringify({
         title,
         content,

--- a/src/apis/imojumo/proConDiscussions.ts
+++ b/src/apis/imojumo/proConDiscussions.ts
@@ -1,15 +1,12 @@
 import {
   GetProConDiscussionType,
-  ProConDiscussionRequest,
   GetProConDiscussionDetailType,
+  UpdateProConDiscussionType,
+  CreateProConDiscussionType,
 } from '../../types';
 import request from '../api';
 
 const { VITE_API_URL } = import.meta.env;
-
-export interface CreateProConDiscussionType extends ProConDiscussionRequest {
-  token?: string | null;
-}
 
 export async function createProConDiscussion({
   title,
@@ -67,6 +64,33 @@ export async function getProConDiscussionDetail(
         'ngrok-skip-browser-warning': '12',
         ...(token && { Authorization: token }),
       },
+    },
+  });
+
+  return response;
+}
+
+export async function updateProConDiscussion({
+  id,
+  title,
+  content,
+  isPro,
+  token,
+}: UpdateProConDiscussionType) {
+  const response = await request({
+    url: `${VITE_API_URL}/pro-con-discussions/${id}`,
+    options: {
+      method: 'PATCH',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `${token}`,
+      },
+      credentials: 'include',
+      body: JSON.stringify({
+        title,
+        content,
+        isPro,
+      }),
     },
   });
 

--- a/src/apis/proConDiscussion.ts
+++ b/src/apis/proConDiscussion.ts
@@ -1,112 +1,88 @@
-import { ProConDiscussionInfo, Comment } from '../types';
+import {
+  CreateProConVoteType,
+  DeleteProConDiscussionType,
+  GetProConDiscussionDetailType,
+  ProConDiscussion,
+  ProConVote,
+  UpdateProConVoteType,
+} from '../types';
+
+import request from './api';
 
 const { VITE_API_URL } = import.meta.env;
 
-interface ProConDiscussion extends ProConDiscussionInfo {
-  isPro: boolean;
-  isVote: boolean;
-  comments: Comment[];
-}
-
-interface ProConVote {
-  isPro: boolean;
-}
-
-export async function getProConDiscussion(
-  id: string,
-  token: string,
-): Promise<ProConDiscussion> {
-  try {
-    const response = await fetch(`${VITE_API_URL}/pro-con-discussions/${id}`, {
+export async function getProConDiscussionDetail({
+  id,
+  token,
+}: GetProConDiscussionDetailType): Promise<ProConDiscussion> {
+  const response = await request({
+    url: `${VITE_API_URL}/pro-con-discussions/${id}`,
+    options: {
       method: 'GET',
       headers: {
         'Content-Type': 'application/json',
         Authorization: `${token}`,
       },
-    });
+    },
+  });
 
-    if (!response.ok) {
-      const error = await response.json();
-      throw new Error(error.message);
-    }
-
-    return (await response.json()) as ProConDiscussion;
-  } catch (error) {
-    console.log(error);
-    throw error;
-  }
+  return response;
 }
 
-export async function deleteProConDiscussion(id: number, token: string) {
-  try {
-    const response = await fetch(`${VITE_API_URL}/pro-con-discussions/${id}`, {
+export async function deleteProConDiscussion({
+  id,
+  token,
+}: DeleteProConDiscussionType) {
+  const response = await request({
+    url: `${VITE_API_URL}/pro-con-discussions/${id}`,
+    options: {
       method: 'DELETE',
       headers: {
         'Content-Type': 'application/json',
         Authorization: `${token}`,
       },
-    });
+    },
+  });
 
-    if (!response.ok) {
-      const error = await response.json();
-      throw new Error(error.message);
-    }
-  } catch (error) {
-    console.log(error);
-    throw error;
-  }
+  return response;
 }
 
-export async function createProConVote(
-  id: string,
-  token: string,
-  voteValue: boolean,
-): Promise<ProConVote> {
-  try {
-    const response = await fetch(`${VITE_API_URL}/pro-con-vote/${id}`, {
+export async function createProConVote({
+  id,
+  token,
+  voteValue,
+}: CreateProConVoteType): Promise<ProConVote> {
+  const response = await request({
+    url: `${VITE_API_URL}/pro-con-vote/${id}`,
+    options: {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
         Authorization: `${token}`,
       },
       body: JSON.stringify({ isPro: voteValue }),
-    });
+    },
+  });
 
-    if (!response.ok) {
-      const error = await response.json();
-      throw new Error(error.message);
-    }
-
-    return (await response.json()) as ProConVote;
-  } catch (error) {
-    console.error(error);
-    throw error;
-  }
+  return response;
 }
 
-export async function updateProConVote(
-  id: string,
-  token: string,
-  voteValue: boolean,
-): Promise<ProConVote> {
-  try {
-    const response = await fetch(`${VITE_API_URL}/pro-con-vote/${id}`, {
+export async function updateProConVote({
+  id,
+  token,
+  voteValue,
+}: UpdateProConVoteType): Promise<ProConVote> {
+  const response = await request({
+    url: `${VITE_API_URL}/pro-con-vote/${id}`,
+    options: {
       method: 'PATCH',
       headers: {
         'Content-Type': 'application/json',
         Authorization: `${token}`,
       },
       body: JSON.stringify({ isPro: voteValue }),
-    });
+    },
+  });
 
-    if (!response.ok) {
-      const error = await response.json();
-      throw new Error(error.message);
-    }
-
-    return (await response.json()) as ProConVote;
-  } catch (error) {
-    console.error(error);
-    throw error;
-  }
+  return response;
 }

--- a/src/components/BookDiscussionDetail/DiscussionInformation.tsx
+++ b/src/components/BookDiscussionDetail/DiscussionInformation.tsx
@@ -12,11 +12,10 @@ import { alignCenter, colFlex, rowFlex } from '../../styles/shared';
 import useModal from '../../hooks/useModal';
 import { jwtAtom, userInfoAtom } from '../../recoil/atoms';
 import isLoginSelector from '../../recoil/seletors';
-import {
-  deleteBookDiscussion,
-  likeBookDiscussion,
-  unlikeBookDiscussion,
-} from '../../apis/bookDiscussion';
+
+import useDeleteBookDiscussion from '../../hooks/bookDiscussion/useDeleteBookDiscission';
+import useCreateLike from '../../hooks/postLike/useCreateLike';
+import useDeleteLike from '../../hooks/postLike/useDeleteLike';
 
 interface DiscussioninformationProps {
   id: number;
@@ -49,14 +48,36 @@ function DiscussionInformation({
   const [showModal, handleShowModal, handleCloseModal] = useModal();
   const [isLike, setIsLike] = useState(postLikedByUser);
 
+  const { mutate: deleteBookDiscussion } = useDeleteBookDiscussion({
+    onSuccess: () => {
+      navigate('/book-discussion');
+    },
+  });
+
+  const { mutate: createLike } = useCreateLike({
+    onSuccess: () => {
+      setIsLike(true);
+    },
+    onError: (error) => {
+      console.log(error);
+    },
+  });
+
+  const { mutate: deleteLike } = useDeleteLike({
+    onSuccess: () => {
+      setIsLike(false);
+    },
+    onError: (error) => {
+      console.log(error);
+    },
+  });
+
   const handleEdit = () => {
-    // 게시글 수정 추가 예정
     navigate(`/book-discussion/${id}/edit`);
   };
 
   const handleDelete = () => {
-    deleteBookDiscussion(id, token);
-    navigate('/book-discussion');
+    deleteBookDiscussion({ id, token });
   };
 
   const handleLike = () => {
@@ -66,11 +87,9 @@ function DiscussionInformation({
     }
 
     if (isLike) {
-      unlikeBookDiscussion(id, token);
-      setIsLike(false);
+      deleteLike({ postId: id, token });
     } else {
-      likeBookDiscussion(id, token);
-      setIsLike(true);
+      createLike({ postId: id, token });
     }
   };
 

--- a/src/components/ProConDiscussionDetail/DiscussionInformation.tsx
+++ b/src/components/ProConDiscussionDetail/DiscussionInformation.tsx
@@ -20,7 +20,7 @@ import URL from '../../constants/URL';
 import { ProConLeader } from '../../types';
 import getRate from '../../utils/Rate';
 import { jwtAtom, userInfoAtom } from '../../recoil/atoms';
-import { deleteProConDiscussion } from '../../apis/proConDiscussion';
+import useDeleteProConDiscussion from '../../hooks/proConDiscussion/useDeleteProConDiscussion';
 
 interface DiscussioninformationProps {
   id: number;
@@ -45,6 +45,15 @@ function DiscussionInformation({
 }: DiscussioninformationProps) {
   const navigate = useNavigate();
 
+  const { mutate: deleteProConDiscussion } = useDeleteProConDiscussion({
+    onSuccess: () => {
+      navigate('/pro-con-discussion');
+    },
+    onError: (error) => {
+      console.log(error);
+    },
+  });
+
   const token = useRecoilValue(jwtAtom) ?? '';
   const user = useRecoilValue(userInfoAtom);
   const { username } = user;
@@ -67,9 +76,8 @@ function DiscussionInformation({
     navigate('/posts/new/pro-con-discussion');
   };
 
-  const handleDelete = () => {
-    deleteProConDiscussion(id, token);
-    navigate('/pro-con-discussion');
+  const handleDelete = async () => {
+    await deleteProConDiscussion({ id: String(id), token });
   };
 
   return (

--- a/src/hooks/bookDiscussion/useBookDiscussionDetail.ts
+++ b/src/hooks/bookDiscussion/useBookDiscussionDetail.ts
@@ -7,7 +7,7 @@ import {
 
 import { getBookDiscussion } from '../../apis/bookDiscussion';
 
-interface useBookDiscussionDetailProps extends GetBookDiscussionDetailType {
+interface UseBookDiscussionDetailProps extends GetBookDiscussionDetailType {
   isSuspense?: boolean;
   isErrorBoundary?: boolean;
   onSuccess?: (data: BookDiscussionDetail | null) => void;
@@ -21,7 +21,7 @@ function useBookDiscussionDetail({
   onError,
   isSuspense = false,
   isErrorBoundary = false,
-}: useBookDiscussionDetailProps) {
+}: UseBookDiscussionDetailProps) {
   const { data, isLoading, error } = useQuery<
     GetBookDiscussionDetailType,
     BookDiscussionDetail

--- a/src/hooks/bookDiscussion/useDeleteBookDiscission.ts
+++ b/src/hooks/bookDiscussion/useDeleteBookDiscission.ts
@@ -1,0 +1,31 @@
+import { deleteBookDiscussion } from '../../apis/bookDiscussion';
+import {
+  APIError,
+  BookDiscussionInfo,
+  DeleteBookDiscussionType,
+} from '../../types';
+
+import useMutate from '../useMutate';
+
+interface UseDeleteBookDiscussionProps {
+  onSuccess?: (data: BookDiscussionInfo) => void;
+  onError?: (error: Error | APIError) => void;
+}
+
+function useDeleteBookDiscussion({
+  onSuccess,
+  onError,
+}: UseDeleteBookDiscussionProps) {
+  const { mutate, data, error, isLoading } = useMutate<
+    DeleteBookDiscussionType,
+    any
+  >({
+    fetchFn: deleteBookDiscussion,
+    onSuccess,
+    onError,
+  });
+
+  return { mutate, data, error, isLoading };
+}
+
+export default useDeleteBookDiscussion;

--- a/src/hooks/proConDiscussion/useCreateProConDiscussion.ts
+++ b/src/hooks/proConDiscussion/useCreateProConDiscussion.ts
@@ -1,11 +1,12 @@
+import { createProConDiscussion } from '../../apis/imojumo/proConDiscussions';
 import {
+  APIError,
   CreateProConDiscussionType,
-  createProConDiscussion,
-} from '../../apis/imojumo/proConDiscussions';
-import { APIError, ProConDiscussionInfo } from '../../types';
+  ProConDiscussionInfo,
+} from '../../types';
 import useMutate from '../useMutate';
 
-interface UseCreateProConDiscussionPrps {
+interface UseCreateProConDiscussionProps {
   onSuccess?: (data: ProConDiscussionInfo) => void;
   onError?: (error: Error | APIError) => void;
 }
@@ -13,7 +14,7 @@ interface UseCreateProConDiscussionPrps {
 function useCreateProConDiscussion({
   onSuccess,
   onError,
-}: UseCreateProConDiscussionPrps) {
+}: UseCreateProConDiscussionProps) {
   const { mutate, data, error, isLoading } = useMutate<
     CreateProConDiscussionType,
     any

--- a/src/hooks/proConDiscussion/useDeleteProConDiscussion.ts
+++ b/src/hooks/proConDiscussion/useDeleteProConDiscussion.ts
@@ -1,0 +1,26 @@
+import { deleteProConDiscussion } from '../../apis/proConDiscussion';
+import { APIError, DeleteProConDiscussionType } from '../../types';
+import useMutate from '../useMutate';
+
+interface UseDeleteProConDiscussionProps {
+  onSuccess?: () => void;
+  onError?: (error: Error | APIError) => void;
+}
+
+function useDeleteProConDiscussion({
+  onSuccess,
+  onError,
+}: UseDeleteProConDiscussionProps) {
+  const { mutate, data, error, isLoading } = useMutate<
+    DeleteProConDiscussionType,
+    any
+  >({
+    fetchFn: deleteProConDiscussion,
+    onSuccess,
+    onError,
+  });
+
+  return { mutate, data, error, isLoading };
+}
+
+export default useDeleteProConDiscussion;

--- a/src/hooks/proConDiscussion/useProConDiscussionDetail.ts
+++ b/src/hooks/proConDiscussion/useProConDiscussionDetail.ts
@@ -1,0 +1,55 @@
+import useQuery from '../useQuery';
+import {
+  APIError,
+  GetProConDiscussionDetailType,
+  ProConDiscussion,
+} from '../../types';
+import { getProConDiscussionDetail } from '../../apis/proConDiscussion';
+
+interface UseProConDiscussionDetailProps extends GetProConDiscussionDetailType {
+  isSuspense?: boolean;
+  isErrorBoundary?: boolean;
+  onSuccess?: (data: ProConDiscussion | null) => void;
+  onError?: (error: Error | APIError) => void;
+}
+
+function useProConDiscussionDetail({
+  id,
+  token,
+  onSuccess,
+  onError,
+  isSuspense = false,
+  isErrorBoundary = false,
+}: UseProConDiscussionDetailProps) {
+  const { data, isLoading, error, setData } = useQuery<
+    GetProConDiscussionDetailType,
+    ProConDiscussion
+  >({
+    fetchFn: getProConDiscussionDetail,
+    arg: { id, token },
+    isErrorBoundary,
+    isSuspense,
+    onSuccess,
+    onError,
+  });
+
+  const handleUpdateIsPro = (isPro: boolean) => {
+    setData((prev) => {
+      if (prev === undefined) {
+        return prev;
+      }
+
+      return {
+        ...prev,
+        isPro,
+        isVote: true,
+      };
+    });
+  };
+
+  console.log(data);
+
+  return { data, isLoading, error, handleUpdateIsPro };
+}
+
+export default useProConDiscussionDetail;

--- a/src/hooks/proConDiscussion/useProConDiscussionDetail.ts
+++ b/src/hooks/proConDiscussion/useProConDiscussionDetail.ts
@@ -47,8 +47,6 @@ function useProConDiscussionDetail({
     });
   };
 
-  console.log(data);
-
   return { data, isLoading, error, handleUpdateIsPro };
 }
 

--- a/src/hooks/proConDiscussion/useUpdateProConDiscussion.ts
+++ b/src/hooks/proConDiscussion/useUpdateProConDiscussion.ts
@@ -12,7 +12,7 @@ interface UseUpdateProConDiscussionProps {
   onError?: (error: Error | APIError) => void;
 }
 
-function useCreateBookDiscussion({
+function useUpdateProConDiscussion({
   onSuccess,
   onError,
 }: UseUpdateProConDiscussionProps) {
@@ -28,4 +28,4 @@ function useCreateBookDiscussion({
   return { mutate, data, error, isLoading };
 }
 
-export default useCreateBookDiscussion;
+export default useUpdateProConDiscussion;

--- a/src/hooks/proConDiscussion/useUpdateProConDiscussion.ts
+++ b/src/hooks/proConDiscussion/useUpdateProConDiscussion.ts
@@ -1,0 +1,31 @@
+import { updateProConDiscussion } from '../../apis/imojumo/proConDiscussions';
+import {
+  APIError,
+  BookDiscussionInfo,
+  UpdateProConDiscussionType,
+} from '../../types';
+
+import useMutate from '../useMutate';
+
+interface UseUpdateProConDiscussionProps {
+  onSuccess?: (data: BookDiscussionInfo) => void;
+  onError?: (error: Error | APIError) => void;
+}
+
+function useCreateBookDiscussion({
+  onSuccess,
+  onError,
+}: UseUpdateProConDiscussionProps) {
+  const { mutate, data, error, isLoading } = useMutate<
+    UpdateProConDiscussionType,
+    any
+  >({
+    fetchFn: updateProConDiscussion,
+    onSuccess,
+    onError,
+  });
+
+  return { mutate, data, error, isLoading };
+}
+
+export default useCreateBookDiscussion;

--- a/src/hooks/proConVote/useCreateProConVote.ts
+++ b/src/hooks/proConVote/useCreateProConVote.ts
@@ -1,0 +1,23 @@
+import { createProConVote } from '../../apis/proConDiscussion';
+import { APIError, CreateProConVoteType, ProConVote } from '../../types';
+import useMutate from '../useMutate';
+
+interface UseCreateProConVoteProps {
+  onSuccess?: (data: ProConVote | null) => void;
+  onError?: (error: Error | APIError) => void;
+}
+
+function useCreateProConVote({ onSuccess, onError }: UseCreateProConVoteProps) {
+  const { mutate, data, error, isLoading } = useMutate<
+    CreateProConVoteType,
+    ProConVote
+  >({
+    fetchFn: createProConVote,
+    onSuccess,
+    onError,
+  });
+
+  return { mutate, data, error, isLoading };
+}
+
+export default useCreateProConVote;

--- a/src/hooks/proConVote/useUpdateProConVote.ts
+++ b/src/hooks/proConVote/useUpdateProConVote.ts
@@ -1,0 +1,23 @@
+import { updateProConVote } from '../../apis/proConDiscussion';
+import { APIError, ProConVote, UpdateProConVoteType } from '../../types';
+import useMutate from '../useMutate';
+
+interface UseUpdateProConVoteProps {
+  onSuccess?: (data: ProConVote | null) => void;
+  onError?: (error: Error | APIError) => void;
+}
+
+function useUpdateProConVote({ onSuccess, onError }: UseUpdateProConVoteProps) {
+  const { mutate, data, error, isLoading } = useMutate<
+    UpdateProConVoteType,
+    ProConVote
+  >({
+    fetchFn: updateProConVote,
+    onSuccess,
+    onError,
+  });
+
+  return { mutate, data, error, isLoading };
+}
+
+export default useUpdateProConVote;

--- a/src/types/BookDiscussionPost.type.ts
+++ b/src/types/BookDiscussionPost.type.ts
@@ -74,3 +74,8 @@ export interface BookDiscussionDetail extends BookDiscussionInfo {
   postLikedByUser: boolean;
   comments: Comment[];
 }
+
+export interface DeleteBookDiscussionType {
+  id: number;
+  token?: string;
+}

--- a/src/types/ProConDiscussionPost.type.ts
+++ b/src/types/ProConDiscussionPost.type.ts
@@ -44,3 +44,15 @@ export interface UseProConDiscussionType extends GetProConDiscussionType {
   isSuspense?: boolean;
   isErrorBoundary?: boolean;
 }
+
+export interface UpdateProConDiscussionType {
+  id: number;
+  isPro: boolean;
+  title: string;
+  content: string;
+  token: string;
+}
+
+export interface CreateProConDiscussionType extends ProConDiscussionRequest {
+  token?: string | null;
+}

--- a/src/types/ProConDiscussionPost.type.ts
+++ b/src/types/ProConDiscussionPost.type.ts
@@ -1,4 +1,4 @@
-import { PageInfo } from './index';
+import { Comment, PageInfo } from './index';
 
 export interface ProConDiscussionInfo {
   id: number;
@@ -55,4 +55,15 @@ export interface UpdateProConDiscussionType {
 
 export interface CreateProConDiscussionType extends ProConDiscussionRequest {
   token?: string | null;
+}
+
+export interface ProConDiscussion extends ProConDiscussionInfo {
+  isPro: boolean;
+  isVote: boolean;
+  comments: Comment[];
+}
+
+export interface DeleteProConDiscussionType {
+  id: string;
+  token: string;
 }

--- a/src/types/ProConVote.type.ts
+++ b/src/types/ProConVote.type.ts
@@ -1,0 +1,15 @@
+export interface ProConVote {
+  isPro: boolean;
+}
+
+export interface CreateProConVoteType {
+  id: string;
+  token: string;
+  voteValue: boolean;
+}
+
+export interface UpdateProConVoteType {
+  id: string;
+  token: string;
+  voteValue: boolean;
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -7,3 +7,4 @@ export * from './LikeList.type';
 export * from './Comment.type';
 export * from './Promise.type';
 export * from './Error.type';
+export * from './ProConVote.type';


### PR DESCRIPTION
### 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요. -->
- #149 

### ✨개발 내용
<!-- 개발한 내용을 설명을 적어주세요 -->
> 토론 수정 기능 구현에 앞서, 토론 상세와 공통적으로 fetch들이 존재하여 useQuery, useMutate를 이용한 패칭 방식으로 통일시키는 작업을 진행했습니다.

- request 공통 모듈 수정
  - eslint에서 RequestInit 타입인식이 정상적으로 되지 않아 설정 추가 (RequestInitsms fetch의 옵션부분 타입)
    ```ts
    globals: {
      RequestInit: 'readonly',
    },
    ```
  - Status 204 (content 없음)에 대해 예외처리 추가
    ```ts
    if (response.status === 204) {
      return response;
    }
    ```

- fetch -> reqeust 공통 모듈 적용
  - deleteBookDiscussion
  - likeBookDiscussion
  - unlikeBookDiscussion
  - updateProConDiscussion
  - getProConDiscussionDetail
  - deleteProConDiscussion
  - createProConVote
  - updateProConVote

- 각 fetch 커스텀 hooks 생성
   - useDeleteBookDiscussion
   - useDeleteProConDiscussion
   - useProConDiscussionDetail
   - useCreateBookDiscussion
   - useCreateProConVote
   - useUpdateProConVote

- 그 외 구현 사항
  - useProConDiscussionDetail에 찬반 여부를 업데이트하는 `handleUpdateIsPro`를 hooks 내에 생성
  - useBookDiscussionDetailProps  -> UseBookDiscussionDetailProps 소문자 오타 수정


