### PR TITLE
[Feature] 찬반 토론 기능구현, 독서 토론 수정

### DIFF
--- a/src/components/BookDiscussionEditForm/BookDiscussionEditForm.tsx
+++ b/src/components/BookDiscussionEditForm/BookDiscussionEditForm.tsx
@@ -1,9 +1,7 @@
 import React, { useEffect } from 'react';
-import styled from 'styled-components';
 import { useRecoilValue } from 'recoil';
 import { useNavigate, useParams } from 'react-router-dom';
 
-import Button from '../UI/Button/Button';
 import DiscussionFormInputs from '../DiscussionForm/DiscussionFormInputs';
 import DiscussionForm from '../DiscussionForm/DiscussionForm';
 import DiscussionSearchBook from '../DiscussionForm/DiscussionSearchBook';
@@ -13,6 +11,7 @@ import useUpdateBookDiscussion from '../../hooks/bookDiscussion/useUpdateBookDis
 
 import { jwtAtom } from '../../recoil/atoms';
 import useBookDiscussionDetail from '../../hooks/bookDiscussion/useBookDiscussionDetail';
+import DiscussionFormSubmitButton from '../DiscussionForm/DiscussionFormSubmitButton';
 
 function BookDiscussionEditForm() {
   const navigate = useNavigate();
@@ -38,7 +37,7 @@ function BookDiscussionEditForm() {
   });
 
   const getDisabledSubmitButton = () => {
-    if (isLoading) {
+    if (isLoading || !bookDiscussionDetail) {
       return false;
     }
 
@@ -47,8 +46,8 @@ function BookDiscussionEditForm() {
     }
 
     if (
-      title !== bookDiscussionDetail?.title ||
-      content !== bookDiscussionDetail?.content
+      title !== bookDiscussionDetail.title ||
+      content !== bookDiscussionDetail.content
     ) {
       return false;
     }
@@ -94,39 +93,21 @@ function BookDiscussionEditForm() {
       />
       <DiscussionFormInputs
         avatar={bookDiscussionDetail?.avatarUrl || null}
+        author={bookDiscussionDetail?.author || ''}
         title={title}
         content={content}
         onChange={onChange}
         containerHeight="300px"
       />
 
-      <SubmitButton
-        type="submit"
-        buttonType="button"
-        buttonColor="pink"
-        buttonSize="l"
+      <DiscussionFormSubmitButton
         onClick={handleFormSubmit}
         disabled={disabledSubmitButton}
       >
         수정하기
-      </SubmitButton>
+      </DiscussionFormSubmitButton>
     </DiscussionForm>
   );
 }
-
-const SubmitButton = styled(Button)`
-  align-self: center;
-
-  &:disabled {
-    cursor: default;
-    background: var(--color-placeholder);
-    box-shadow: inset 0px 1px 0px 0px var(--color-placeholder);
-    border-color: var(--color-placeholder);
-
-    &:active {
-      top: 0px;
-    }
-  }
-`;
 
 export default BookDiscussionEditForm;

--- a/src/components/BookDiscussionNewForm/BookDiscussionNewForm.tsx
+++ b/src/components/BookDiscussionNewForm/BookDiscussionNewForm.tsx
@@ -1,9 +1,7 @@
 import React, { useState } from 'react';
-import styled from 'styled-components';
 import { useRecoilValue } from 'recoil';
 import { useNavigate } from 'react-router-dom';
 
-import Button from '../UI/Button/Button';
 import DiscussionFormInputs from '../DiscussionForm/DiscussionFormInputs';
 import DiscussionForm from '../DiscussionForm/DiscussionForm';
 import DiscussionSearchBook from '../DiscussionForm/DiscussionSearchBook';
@@ -13,6 +11,7 @@ import useCreateBookDiscussion from '../../hooks/bookDiscussion/useCreateBookDis
 
 import { AladinBookSearchItem } from '../../types';
 import { jwtAtom, userInfoAtom } from '../../recoil/atoms';
+import DiscussionFormSubmitButton from '../DiscussionForm/DiscussionFormSubmitButton';
 
 function BookDiscussionNewForm() {
   const [{ title, content }, onChange] = useInputs({
@@ -31,7 +30,7 @@ function BookDiscussionNewForm() {
   const disabledSubmitButton =
     isLoading || book === null || title.length === 0 || content.length === 0;
   const token = useRecoilValue(jwtAtom);
-  const { avatarUrl } = useRecoilValue(userInfoAtom);
+  const { avatarUrl, username } = useRecoilValue(userInfoAtom);
   const navigate = useNavigate();
 
   const handleFormSubmit = async (
@@ -77,39 +76,21 @@ function BookDiscussionNewForm() {
       <DiscussionSearchBook onSearch={handleSearch} />
       <DiscussionFormInputs
         avatar={avatarUrl}
+        author={username || ''}
         title={title}
         content={content}
         onChange={onChange}
         containerHeight="300px"
       />
 
-      <SubmitButton
-        type="submit"
-        buttonType="button"
-        buttonColor="pink"
-        buttonSize="l"
+      <DiscussionFormSubmitButton
         onClick={handleFormSubmit}
         disabled={disabledSubmitButton}
       >
         등록하기
-      </SubmitButton>
+      </DiscussionFormSubmitButton>
     </DiscussionForm>
   );
 }
-
-const SubmitButton = styled(Button)`
-  align-self: center;
-
-  &:disabled {
-    cursor: default;
-    background: var(--color-placeholder);
-    box-shadow: inset 0px 1px 0px 0px var(--color-placeholder);
-    border-color: var(--color-placeholder);
-
-    &:active {
-      top: 0px;
-    }
-  }
-`;
 
 export default BookDiscussionNewForm;

--- a/src/components/DiscussionForm/DiscussionFormInputs.tsx
+++ b/src/components/DiscussionForm/DiscussionFormInputs.tsx
@@ -9,6 +9,7 @@ import UserProfile from '../UI/UserProfile/UserProfile';
 
 interface DiscussionFormInputsProps {
   avatar: string | null;
+  author: string;
   title: string;
   content: string;
   containerHeight: string;
@@ -21,6 +22,7 @@ interface DiscussionFormInputsProps {
 
 function DiscussionFormInputs({
   avatar,
+  author,
   title,
   content,
   containerHeight,
@@ -36,9 +38,9 @@ function DiscussionFormInputs({
 
       <UserProfile
         avatar={avatar}
-        alt="프로필 이미지"
+        alt={`${author} 프로필 이미지`}
         itemGap="10px"
-        nickname="yua77"
+        nickname={author}
         size="sm"
       />
       <DiscussionInputContainer>

--- a/src/components/DiscussionForm/DiscussionFormInputs.tsx
+++ b/src/components/DiscussionForm/DiscussionFormInputs.tsx
@@ -72,12 +72,14 @@ function DiscussionFormInputs({
           name="title"
           value={title}
           placeholder="토론 제목을 입력하세요..."
+          aria-label="제목"
           onChange={onChange}
         />
         <DiscussionContentInput
           name="content"
           value={content}
           placeholder="내용을 입력하세요..."
+          aria-label="내용"
           onChange={onChange}
         />
       </DiscussionInputContainer>

--- a/src/components/DiscussionForm/DiscussionFormSubmitButton.tsx
+++ b/src/components/DiscussionForm/DiscussionFormSubmitButton.tsx
@@ -4,6 +4,7 @@ import Button from '../UI/Button/Button';
 
 interface DiscussionFormSubmitButtonProps {
   disabled: boolean;
+  ariaLabel?: string;
   children: React.ReactNode;
   onClick: (
     event:
@@ -13,6 +14,7 @@ interface DiscussionFormSubmitButtonProps {
 }
 
 function DiscussionFormSubmitButton({
+  ariaLabel,
   disabled,
   children,
   onClick,
@@ -23,6 +25,7 @@ function DiscussionFormSubmitButton({
       buttonType="button"
       buttonColor="pink"
       buttonSize="l"
+      aria-label={ariaLabel}
       onClick={onClick}
       disabled={disabled}
     >

--- a/src/components/DiscussionForm/DiscussionFormSubmitButton.tsx
+++ b/src/components/DiscussionForm/DiscussionFormSubmitButton.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import styled from 'styled-components';
+import Button from '../UI/Button/Button';
+
+interface DiscussionFormSubmitButtonProps {
+  disabled: boolean;
+  children: React.ReactNode;
+  onClick: (
+    event:
+      | React.MouseEvent<HTMLButtonElement>
+      | React.FormEvent<HTMLFormElement>,
+  ) => Promise<void>;
+}
+
+function DiscussionFormSubmitButton({
+  disabled,
+  children,
+  onClick,
+}: DiscussionFormSubmitButtonProps) {
+  return (
+    <SubmitButton
+      type="submit"
+      buttonType="button"
+      buttonColor="pink"
+      buttonSize="l"
+      onClick={onClick}
+      disabled={disabled}
+    >
+      {children}
+    </SubmitButton>
+  );
+}
+
+const SubmitButton = styled(Button)`
+  align-self: center;
+
+  &:disabled {
+    cursor: default;
+    background: var(--color-placeholder);
+    box-shadow: inset 0px 1px 0px 0px var(--color-placeholder);
+    border-color: var(--color-placeholder);
+
+    &:active {
+      top: 0px;
+    }
+  }
+`;
+
+export default DiscussionFormSubmitButton;

--- a/src/components/ProConDiscussionDetail/DiscussionInformation.tsx
+++ b/src/components/ProConDiscussionDetail/DiscussionInformation.tsx
@@ -72,8 +72,7 @@ function DiscussionInformation({
   const conLeaderAvatar = conLeader?.avatarUrl || URL.NONE_AVATA_URL;
 
   const handleEdit = () => {
-    // 게시글 수정 추가 예정
-    navigate('/posts/new/pro-con-discussion');
+    navigate(`/pro-con-discussion/${id}/edit`);
   };
 
   const handleDelete = async () => {

--- a/src/components/ProConDiscussionEditForm/ProConDiscussionEditForm.tsx
+++ b/src/components/ProConDiscussionEditForm/ProConDiscussionEditForm.tsx
@@ -56,7 +56,6 @@ function ProConDiscussionEditForm() {
     }
 
     if (title.length === 0 || content.length === 0) {
-      console.log(1111);
       return false;
     }
 

--- a/src/components/ProConDiscussionEditForm/ProConDiscussionEditForm.tsx
+++ b/src/components/ProConDiscussionEditForm/ProConDiscussionEditForm.tsx
@@ -1,0 +1,113 @@
+import React, { useState } from 'react';
+import { useRecoilValue } from 'recoil';
+import { useNavigate, useParams } from 'react-router-dom';
+
+import DiscussionForm from '../DiscussionForm/DiscussionForm';
+import DiscussionFormInputs from '../DiscussionForm/DiscussionFormInputs';
+
+import useInputs from '../../hooks/useInputs';
+import { jwtAtom } from '../../recoil/atoms';
+import useUpdateProConDiscussion from '../../hooks/proConDiscussion/useUpdateProConDiscussion';
+import useProConDiscussionDetail from '../../hooks/proConDiscussion/useProConDiscussionDetail';
+import Loading from '../UI/Loading/Loading';
+import DiscussionFormSubmitButton from '../DiscussionForm/DiscussionFormSubmitButton';
+
+function ProConDiscussionEditForm() {
+  const navigate = useNavigate();
+  const { postId } = useParams() || '';
+  const token = useRecoilValue(jwtAtom) ?? '';
+
+  const [isPro, setIsPro] = useState(true);
+  const [{ title, content }, onChange, _, __, setInputs] = useInputs({
+    title: '',
+    content: '',
+  });
+
+  const { data: proConDiscussionDetail, isLoading: isGetDataLoading } =
+    useProConDiscussionDetail({
+      token,
+      delay: 500,
+      id: Number(postId),
+      onSuccess: (data) => {
+        if (!data) {
+          return;
+        }
+
+        setInputs({
+          title: data.title,
+          content: data.content,
+        });
+        setIsPro(data.isPro);
+      },
+    });
+
+  const { mutate, isLoading } = useUpdateProConDiscussion({
+    onSuccess: (data) => {
+      navigate(`/pro-con-discussion/${data.id}`);
+    },
+    onError: (error) => {
+      console.log(`err: ${error.message[0]}`);
+    },
+  });
+
+  const getDisabledSubmitButton = () => {
+    if (isLoading || !proConDiscussionDetail) {
+      return false;
+    }
+
+    if (title.length === 0 || content.length === 0) {
+      console.log(1111);
+      return false;
+    }
+
+    if (
+      title !== proConDiscussionDetail.title ||
+      content !== proConDiscussionDetail.content ||
+      isPro !== proConDiscussionDetail.isPro
+    ) {
+      return false;
+    }
+    return true;
+  };
+  const disabledSubmitButton = getDisabledSubmitButton();
+
+  const handleFormSubmit = async (
+    event:
+      | React.MouseEvent<HTMLButtonElement>
+      | React.FormEvent<HTMLFormElement>,
+  ) => {
+    event.preventDefault();
+
+    await mutate({ id: Number(postId), title, content, isPro, token });
+  };
+
+  if (isGetDataLoading) {
+    return <Loading />;
+  }
+
+  return (
+    <DiscussionForm title="찬반 토론 작성 입력폼" onSubmit={handleFormSubmit}>
+      <DiscussionFormInputs
+        avatar={proConDiscussionDetail?.avatarUrl || null}
+        author={proConDiscussionDetail?.author || ''}
+        title={title}
+        content={content}
+        onChange={onChange}
+        containerHeight="524px"
+        isProConDiscussion
+        isPro={isPro}
+        onProButtonClick={() => setIsPro(true)}
+        onConButtonClick={() => setIsPro(false)}
+      />
+
+      <DiscussionFormSubmitButton
+        onClick={handleFormSubmit}
+        disabled={disabledSubmitButton}
+      >
+        수정하기
+      </DiscussionFormSubmitButton>
+    </DiscussionForm>
+  );
+}
+
+export default ProConDiscussionEditForm;

--- a/src/components/ProConDiscussionNewForm/ProConDiscussionNewForm.tsx
+++ b/src/components/ProConDiscussionNewForm/ProConDiscussionNewForm.tsx
@@ -1,17 +1,17 @@
 import React, { useState } from 'react';
-import styled from 'styled-components';
 import { useRecoilValue } from 'recoil';
 import { useNavigate } from 'react-router-dom';
 
-import Button from '../UI/Button/Button';
 import DiscussionForm from '../DiscussionForm/DiscussionForm';
 import DiscussionFormInputs from '../DiscussionForm/DiscussionFormInputs';
 
 import useCreateProConDiscussion from '../../hooks/proConDiscussion/useCreateProConDiscussion';
 import useInputs from '../../hooks/useInputs';
-import { jwtAtom } from '../../recoil/atoms';
+import { jwtAtom, userInfoAtom } from '../../recoil/atoms';
+import DiscussionFormSubmitButton from '../DiscussionForm/DiscussionFormSubmitButton';
 
 function ProConDiscussionForm() {
+  const { avatarUrl, username } = useRecoilValue(userInfoAtom);
   const [{ title, content }, onChange] = useInputs({
     title: '',
     content: '',
@@ -27,6 +27,8 @@ function ProConDiscussionForm() {
     },
   });
   const token = useRecoilValue(jwtAtom);
+  const disabledSubmitButton =
+    isLoading || title.length === 0 || content.length === 0;
 
   const handleFormSubmit = async (
     event:
@@ -38,13 +40,11 @@ function ProConDiscussionForm() {
     await mutate({ title, content, isPro, token });
   };
 
-  const avatar =
-    'https://image.aladin.co.kr/product/27222/22/cover500/e822538010_1.jpg';
-
   return (
     <DiscussionForm title="찬반 토론 작성 입력폼" onSubmit={handleFormSubmit}>
       <DiscussionFormInputs
-        avatar={avatar}
+        avatar={avatarUrl}
+        author={username || ''}
         title={title}
         content={content}
         onChange={onChange}
@@ -55,21 +55,14 @@ function ProConDiscussionForm() {
         onConButtonClick={() => setIsPro(false)}
       />
 
-      <SubmitButton
-        type="submit"
-        buttonType="button"
-        buttonColor="pink"
-        buttonSize="l"
+      <DiscussionFormSubmitButton
         onClick={handleFormSubmit}
+        disabled={disabledSubmitButton}
       >
         등록하기
-      </SubmitButton>
+      </DiscussionFormSubmitButton>
     </DiscussionForm>
   );
 }
-
-const SubmitButton = styled(Button)`
-  align-self: center;
-`;
 
 export default ProConDiscussionForm;

--- a/src/hooks/proConDiscussion/useProConDiscussionDetail.ts
+++ b/src/hooks/proConDiscussion/useProConDiscussionDetail.ts
@@ -9,6 +9,7 @@ import { getProConDiscussionDetail } from '../../apis/proConDiscussion';
 interface UseProConDiscussionDetailProps extends GetProConDiscussionDetailType {
   isSuspense?: boolean;
   isErrorBoundary?: boolean;
+  delay?: number;
   onSuccess?: (data: ProConDiscussion | null) => void;
   onError?: (error: Error | APIError) => void;
 }
@@ -18,10 +19,11 @@ function useProConDiscussionDetail({
   token,
   onSuccess,
   onError,
+  delay = 0,
   isSuspense = false,
   isErrorBoundary = false,
 }: UseProConDiscussionDetailProps) {
-  const { data, isLoading, error, setData } = useQuery<
+  const { data, isLoading, error, setData, refetch } = useQuery<
     GetProConDiscussionDetailType,
     ProConDiscussion
   >({
@@ -31,6 +33,7 @@ function useProConDiscussionDetail({
     isSuspense,
     onSuccess,
     onError,
+    delay,
   });
 
   const handleUpdateIsPro = (isPro: boolean) => {
@@ -47,7 +50,7 @@ function useProConDiscussionDetail({
     });
   };
 
-  return { data, isLoading, error, handleUpdateIsPro };
+  return { data, isLoading, error, handleUpdateIsPro, refetch };
 }
 
 export default useProConDiscussionDetail;

--- a/src/hooks/useInputs.ts
+++ b/src/hooks/useInputs.ts
@@ -16,7 +16,11 @@ function useInputs<T extends Record<string, any>>(initialForm: T) {
     setForm((preState) => ({ ...preState, [name]: value }));
   };
 
-  return [form, onChange, reset, setValue] as const;
+  const setValues = (newSatate: T) => {
+    setForm((preState) => ({ ...preState, ...newSatate }));
+  };
+
+  return [form, onChange, reset, setValue, setValues] as const;
 }
 
 export default useInputs;

--- a/src/pages/DiscussionEditPage.tsx
+++ b/src/pages/DiscussionEditPage.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
 import styled from 'styled-components';
+
 import BookDiscussionEditForm from '../components/BookDiscussionEditForm/BookDiscussionEditForm';
-import DiscussionFormTab from '../components/DiscussionForm/DiscussionFormTab';
-import ProConDiscussionForm from '../components/ProConDiscussionNewForm/ProConDiscussionNewForm';
+import ProConDiscussionEditForm from '../components/ProConDiscussionEditForm/ProConDiscussionEditForm';
+
 import MainContainer from '../styles/layout';
 import { flex, screenReaderTextCSS } from '../styles/shared';
 
@@ -20,10 +21,9 @@ function DiscussionEditPage({ discussionType }: DiscussionEditPageProps) {
     <MainContainer>
       <DiscussionEditContainer>
         <DiscussionEditTitle>{title}</DiscussionEditTitle>
-        <DiscussionFormTab />
         {
           {
-            proCon: <ProConDiscussionForm />,
+            proCon: <ProConDiscussionEditForm />,
             book: <BookDiscussionEditForm />,
           }[discussionType]
         }

--- a/src/pages/ProConDiscussionDetailPage.tsx
+++ b/src/pages/ProConDiscussionDetailPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { useRecoilValue } from 'recoil';
 import { BsChatLeftDots, BsInfoCircle } from 'react-icons/bs';
@@ -22,14 +22,13 @@ function ProConDiscussionDetailPage() {
   const token = useRecoilValue(jwtAtom) ?? '';
   const [commentsData, setCommentsData] = useState<Comment[]>([]);
 
-  const { data: proConDiscussion, handleUpdateIsPro } =
-    useProConDiscussionDetail({
-      id: Number(postId),
-      token,
-      onSuccess: (data) => {
-        setCommentsData(data?.comments || []);
-      },
-    });
+  const { data: proConDiscussion, refetch } = useProConDiscussionDetail({
+    id: Number(postId),
+    token,
+    onSuccess: (data) => {
+      setCommentsData(data?.comments || []);
+    },
+  });
 
   const { mutate: createProConVote } = useCreateProConVote({
     onSuccess: (data) => {
@@ -37,7 +36,7 @@ function ProConDiscussionDetailPage() {
         return;
       }
 
-      handleUpdateIsPro(data.isPro);
+      refetch();
     },
   });
 
@@ -47,7 +46,7 @@ function ProConDiscussionDetailPage() {
         return;
       }
 
-      handleUpdateIsPro(data.isPro);
+      refetch();
     },
   });
 

--- a/src/types/ProConDiscussionPost.type.ts
+++ b/src/types/ProConDiscussionPost.type.ts
@@ -2,6 +2,7 @@ import { Comment, PageInfo } from './index';
 
 export interface ProConDiscussionInfo {
   id: number;
+  avatarUrl: string;
   author: string;
   title: string;
   content: string;


### PR DESCRIPTION
### 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요. -->
- #136  

### ✨개발 내용
<!-- 개발한 내용을 설명을 적어주세요 -->
- **`DiscussionFormSubmitButton` 생성** 
  - 신규 토론 생성 버튼, 기존 토론 수정 버튼이 반복되어 공통 컴포넌트로 생성함  

- **독서 토론(BookDiscussion) 기능 수정**
  - getDisabledSubmitButton(변경여부 판단하여 버튼 활성화)에 `옵셔널 삭제`
    - 옵셔널로 인한 `undefined와 문자열을 비교하면 다르다고 판단될 우려`가 있어 수정
      - 수정전
      ```tsx
      const getDisabledSubmitButton = () => {
        if (isLoading) {
    
        if (
          title !== bookDiscussionDetail?.title ||
          content !== bookDiscussionDetail?.content
        ) {
          return false;
        }    
      ```

      - 수정후
      ```tsx
      const getDisabledSubmitButton = () => {
        if (isLoading || !bookDiscussionDetail) {
    
        if (
          title !== bookDiscussionDetail.title ||
          content !== bookDiscussionDetail.content
        ) {
          return false;
        }    
      ```
- **DiscussionFormInputs `author`수정**
   - yua77 고정에서 `author` 수정
     ```tsx
      <UserProfile
        ...
        alt={`${author} 프로필 이미지`}
        nickname={author}
        ...
      />
     ```
   - DiscussionFormInputs 사용 컴포넌트에 author 적용
      - BookDiscussionNewForm, ProConDiscussionNewForm 로그인 유저 정보로 전달
      ```tsx
      const { avatarUrl, username } = useRecoilValue(userInfoAtom); // 저장된 Atom에서 수접
      
      return (
        ...
        <DiscussionFormInputs
          ...
          author={username || ''}
          ...
        />
      )
      ```
      - BookDiscussionEditForm, ProConDiscussionEditForm 작성자 정보로 전달
      ```tsx
      const { data: proConDiscussionDetail, isLoading: isGetDataLoading } =
        useProConDiscussionDetail({
           ...
        });
      
      return (
        ...
        <DiscussionFormInputs
          ...
          author={proConDiscussionDetail.author || ''}
          ...
        />
      )
      ```
      - `EditForm에 로그인 유저가 아닌 get 요청을 통해 작성자명으로 전달한 이유는 본인 이외의 수정권한이 있는 관리자가 수정할 경우 잘 못 표시될 우려가 있다고 판단되어 생성과 다르게 적용했습니다`

- **`ProConDiscussionEditForm `구현**
- **useInputs setValues 추가**
  - 여러 데이터를 한 번에 업데이트하기 위해 구현

- ProConDiscussionDetail handleUpdateIsPro에서 refatch로 수정
   - 기존 수빈님이 구현하신 fetch에서 커스텀 훅 방식으로 변경 과정에서 찬반 변경에 따른 데이터 업데이트하는 부분이 일부만 업데이트되도록 잘 못 수정하여 해결하기 위해 refatch로 변경하였습니다
   ```tsx
  const { mutate: createProConVote } = useCreateProConVote({
    onSuccess: (data) => {
      if (!data) {
        return;
      }

      // handleUpdateIsPro(data.isPro); 기존 찬반 여부 버튼만 업데이트하였음
      refetch();  // 댓글의 찬반 표시와 상단에 proConRate도 재계산될 수 있도록 refach 적용
    },
  });
   ```
<img width="1156" alt="image" src="https://github.com/jumak-dev/imojumo/assets/19286161/dd729ffa-ff85-4fed-8a61-55a47fa30ab0">


### 📸 스크린샷(선택)
<!-- 스크린샷이 필요한 과제면 스크린샷을 첨부해주세요 -->
- 수정화면(버튼 비활성화)
<img width="1089" alt="image" src="https://github.com/jumak-dev/imojumo/assets/19286161/5e4deacf-7e78-4121-bb9c-0ad7cbac6030">

- 수정화면(버튼 활성화)
<img width="1008" alt="image" src="https://github.com/jumak-dev/imojumo/assets/19286161/a5913251-d12f-41dd-ae99-995e037c5faa">

### 👓 고민 사항(선택)
- useInputs의 배열 형태 반환
   - input 창에 초기값 설정을 위해 `setValue(단일 업데이트)`와 `setValues(복수 업데이트)` 를 추가하는 과정에서 배열로 인한 순서때문에 불필요한 _, __  변수를 사용하였습니다. (사용하지 않는 변수에 대해 _ 언더바로 하는 것이 자스 관행)
     ```tsx
     const [{ title, content }, onChange, _, __, setInputs] = useInputs({
        title: '',
        content: '',
      });
     ```
   `-> useInputs를 객체 형식의 반환으로 수정하는게  좋을까요?` 


### 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
<!-- 참고할 사항이 있다면 적어주세요 -->
- git message 리펙토링 지정 기준
  - 리펙토링이란 `결과의 변경 없이 코드의 구조를 재조장함` 입니다
  - 유저 입장에서 변경되는 변경되는 점은 없지만 코드를 개선/수정하는 경우 commit 타입을 리펙토링으로 하면 좋을거 같습니다
  - 이번에 수빈님꺼를 수정하는 과정에서 결과가 변한 리펙토링의 잘 못된 예시였던거 같습니다. 테스트 코드를  작성하고 리펙토링을 하는지 깨닫게 되었습니다.
  - 리펙토링 예시
     - DiscussionFormSubmitButton 적용 -> 버튼을 코드 개선시키고자 컴포넌트화하여 분리하였지만, 유저 입장에서 변화되는 것은 없음 

- 자스 -> 타스는 리펙토링인가요?
  - 네, 결과가 바뀌는 것이 없기때문에 리펙토링입니다
- 성능 개선은 리펙토링인가요?
  - 아니요, 유저 입장에서 변화가 생기기 때문에 리펙토링이 아닙니다 (feat. 원티드 A 강사님) 