### PR TITLE
[Feature] 독서/찬반토론(상세) 댓글 커스텀 훅 적용 및 CSS 수정

### DIFF
--- a/src/apis/comment.ts
+++ b/src/apis/comment.ts
@@ -1,157 +1,119 @@
-import { Comment } from '../types';
+import { CommentType, CommentFormType, Comment } from '../types';
+import request from './api';
 
 const { VITE_API_URL } = import.meta.env;
 
-export async function createComment(
-  id: string,
-  token: string,
-  content: string,
-): Promise<Comment> {
-  try {
-    const response = await fetch(`${VITE_API_URL}/comments?postId=${id}`, {
+export async function createComment({
+  id,
+  token,
+  content,
+}: CommentFormType): Promise<Comment> {
+  const response = await request({
+    url: `${VITE_API_URL}/comments?postId=${id}`,
+    options: {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
         Authorization: `${token}`,
       },
       body: JSON.stringify({ content }),
-    });
+    },
+  });
 
-    if (!response.ok) {
-      const error = await response.json();
-      throw new Error(error.message);
-    }
-
-    return (await response.json()) as Comment;
-  } catch (error) {
-    console.error(error);
-    throw error;
-  }
+  return response;
 }
 
-export async function updateComment(
-  id: number,
-  token: string,
-  content: string,
-): Promise<Comment> {
-  try {
-    const response = await fetch(`${VITE_API_URL}/comments/${id}`, {
+export async function updateComment({
+  id,
+  token,
+  content,
+}: CommentFormType): Promise<Comment> {
+  const response = await request({
+    url: `${VITE_API_URL}/comments/${id}`,
+    options: {
       method: 'PATCH',
       headers: {
         'Content-Type': 'application/json',
         Authorization: `${token}`,
       },
       body: JSON.stringify({ content }),
-    });
+    },
+  });
 
-    if (!response.ok) {
-      const error = await response.json();
-      throw new Error(error.message);
-    }
-
-    return (await response.json()) as Comment;
-  } catch (error) {
-    console.error(error);
-    throw error;
-  }
+  return response;
 }
 
-export async function deleteComment(id: number, token: string) {
-  try {
-    const response = await fetch(`${VITE_API_URL}/comments/${id}`, {
+export async function deleteComment({ id, token }: CommentType) {
+  const response = await request({
+    url: `${VITE_API_URL}/comments/${id}`,
+    options: {
       method: 'DELETE',
       headers: {
         'Content-Type': 'application/json',
         Authorization: `${token}`,
       },
-    });
+    },
+  });
 
-    if (!response.ok) {
-      const error = await response.json();
-      throw new Error(error.message);
-    }
-  } catch (error) {
-    console.error(error);
-    throw error;
-  }
+  return response;
 }
 
-export async function likeComment(id: number, token: string) {
-  try {
-    const response = await fetch(`${VITE_API_URL}/comments/${id}/like`, {
+export async function createCommentLike({ id, token }: CommentType) {
+  const response = await request({
+    url: `${VITE_API_URL}/comments/${id}/like`,
+    options: {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
         Authorization: `${token}`,
       },
-    });
+    },
+  });
 
-    if (!response.ok) {
-      const error = await response.json();
-      throw new Error(error.message);
-    }
-  } catch (error) {
-    console.log(error);
-    throw error;
-  }
+  return response;
 }
 
-export async function cancelCommentLike(id: number, token: string) {
-  try {
-    const response = await fetch(`${VITE_API_URL}/comments/${id}/like`, {
+export async function deleteCommentLike({ id, token }: CommentType) {
+  const response = await request({
+    url: `${VITE_API_URL}/comments/${id}/like`,
+    options: {
       method: 'DELETE',
       headers: {
         'Content-Type': 'application/json',
         Authorization: `${token}`,
       },
-    });
+    },
+  });
 
-    if (!response.ok) {
-      const error = await response.json();
-      throw new Error(error.message);
-    }
-  } catch (error) {
-    console.log(error);
-    throw error;
-  }
+  return response;
 }
 
-export async function dislikeComment(id: number, token: string) {
-  try {
-    const response = await fetch(`${VITE_API_URL}/comments/${id}/dislike`, {
+export async function createCommentDislike({ id, token }: CommentType) {
+  const response = await request({
+    url: `${VITE_API_URL}/comments/${id}/dislike`,
+    options: {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
         Authorization: `${token}`,
       },
-    });
+    },
+  });
 
-    if (!response.ok) {
-      const error = await response.json();
-      throw new Error(error.message);
-    }
-  } catch (error) {
-    console.log(error);
-    throw error;
-  }
+  return response;
 }
 
-export async function cancelCommentDislike(id: number, token: string) {
-  try {
-    const response = await fetch(`${VITE_API_URL}/comments/${id}/dislike`, {
+export async function deleteCommentDislike({ id, token }: CommentType) {
+  const response = await request({
+    url: `${VITE_API_URL}/comments/${id}/dislike`,
+    options: {
       method: 'DELETE',
       headers: {
         'Content-Type': 'application/json',
         Authorization: `${token}`,
       },
-    });
+    },
+  });
 
-    if (!response.ok) {
-      const error = await response.json();
-      throw new Error(error.message);
-    }
-  } catch (error) {
-    console.log(error);
-    throw error;
-  }
+  return response;
 }

--- a/src/apis/imojumo/bookDisccusions.ts
+++ b/src/apis/imojumo/bookDisccusions.ts
@@ -1,6 +1,5 @@
 import {
   GetBookDiscussionType,
-  GetBookDiscussionDetailType,
   UpdateBookDiscussionType,
   CreateBookDiscussionsType,
 } from '../../types';
@@ -41,25 +40,6 @@ export async function getBookDiscussions({
 }: GetBookDiscussionType) {
   const response = await request({
     url: `${VITE_API_URL}/book-discussions?page=${page}&limit=${limit}&orderBy=${orderBy}`,
-    options: {
-      method: 'GET',
-      headers: {
-        'Content-Type': 'application/json',
-        'ngrok-skip-browser-warning': '12',
-        ...(token && { Authorization: token }),
-      },
-    },
-  });
-
-  return response;
-}
-
-export async function getBookDiscussionDetail(
-  { id }: GetBookDiscussionDetailType,
-  token?: string,
-) {
-  const response = await request({
-    url: `${VITE_API_URL}/book-discussions/${id}`,
     options: {
       method: 'GET',
       headers: {

--- a/src/apis/imojumo/proConDiscussions.ts
+++ b/src/apis/imojumo/proConDiscussions.ts
@@ -1,6 +1,5 @@
 import {
   GetProConDiscussionType,
-  GetProConDiscussionDetailType,
   UpdateProConDiscussionType,
   CreateProConDiscussionType,
 } from '../../types';
@@ -44,24 +43,6 @@ export async function getProConDiscussions({
       headers: {
         'Content-Type': 'application/json',
         'ngrok-skip-browser-warning': '12',
-      },
-    },
-  });
-
-  return response;
-}
-
-export async function getProConDiscussionDetail(
-  { id }: GetProConDiscussionDetailType,
-  token?: string,
-) {
-  const response = await request({
-    url: `${VITE_API_URL}/pro-con-discussions/${id}`,
-    options: {
-      method: 'GET',
-      headers: {
-        'ngrok-skip-browser-warning': '12',
-        ...(token && { Authorization: token }),
       },
     },
   });

--- a/src/components/BookDiscussionDetail/BookInformation.tsx
+++ b/src/components/BookDiscussionDetail/BookInformation.tsx
@@ -1,6 +1,7 @@
 import styled from 'styled-components';
 import { colFlex, rowFlex } from '../../styles/shared';
 import { Book } from '../../types';
+import replaceHtml from '../../utils/replaceHtml';
 
 interface BookInformationProps {
   book: Book;
@@ -17,7 +18,11 @@ function BookInformation({ book }: BookInformationProps) {
         <BookInfo>
           {author} | {pubDate} | {publisher} 출판
         </BookInfo>
-        <BookDescription>{description}</BookDescription>
+        <BookDescription>
+          {description.length
+            ? replaceHtml(description)
+            : '해당 도서의 자세한 내용은 곧 업데이트될 예정입니다.'}
+        </BookDescription>
       </BookInfoContainer>
     </InformationContainer>
   );

--- a/src/components/BookDiscussionDetail/DiscussionInformation.tsx
+++ b/src/components/BookDiscussionDetail/DiscussionInformation.tsx
@@ -8,7 +8,12 @@ import { BsDot } from 'react-icons/bs';
 import { Card } from '../UI/Card/Card';
 import Modal from '../UI/Modal/Modal';
 import UserProfile from '../UI/UserProfile/UserProfile';
-import { alignCenter, colFlex, rowFlex } from '../../styles/shared';
+import {
+  alignCenter,
+  colFlex,
+  discussionContentCSS,
+  rowFlex,
+} from '../../styles/shared';
 import useModal from '../../hooks/useModal';
 import { jwtAtom, userInfoAtom } from '../../recoil/atoms';
 import isLoginSelector from '../../recoil/seletors';
@@ -185,13 +190,7 @@ const PostLikeButton = styled.button`
 `;
 
 const DiscussionContent = styled.p`
-  width: 100%;
-  height: 100%;
-  padding: 16px;
-  border-radius: 8px;
-  color: var(--color-content-text);
-  background-color: var(--color-inputbox-bg);
-  line-height: 20px;
+  ${discussionContentCSS}
 `;
 
 export default DiscussionInformation;

--- a/src/components/BookDiscussionDetail/DiscussionInformation.tsx
+++ b/src/components/BookDiscussionDetail/DiscussionInformation.tsx
@@ -20,6 +20,7 @@ import useDeleteLike from '../../hooks/postLike/useDeleteLike';
 interface DiscussioninformationProps {
   id: number;
   author: string;
+  avatarUrl: string;
   title: string;
   content: string;
   createdAt: string;
@@ -29,6 +30,7 @@ interface DiscussioninformationProps {
 function DiscussionInformation({
   id,
   author,
+  avatarUrl,
   title,
   content,
   createdAt,
@@ -38,11 +40,8 @@ function DiscussionInformation({
 
   const isLogin = useRecoilValue(isLoginSelector);
   const token = useRecoilValue(jwtAtom) ?? '';
-  const user = useRecoilValue(userInfoAtom);
-  const { username } = user;
+  const { username } = useRecoilValue(userInfoAtom);
 
-  const imageUrl =
-    'https://blog.kakaocdn.net/dn/MBm88/btquzG0dVpE/GODaepUxVikHoWEkClaPV1/img.png';
   const discussionDate = dayjs(createdAt).format('YYYY-MM-DD');
 
   const [showModal, handleShowModal, handleCloseModal] = useModal();
@@ -96,8 +95,8 @@ function DiscussionInformation({
   return (
     <DiscussionContainer>
       <UserProfile
-        avatar={imageUrl}
-        alt="프로필 이미지"
+        avatar={avatarUrl}
+        alt={`${author} 프로필 이미지`}
         itemGap="10px"
         nickname={author}
         size="lz"
@@ -162,7 +161,7 @@ const DiscussionInfo = styled.div`
 `;
 
 const DiscussionTitle = styled.h2`
-  font-weight: bold;
+  font-weight: 700;
   font-size: var(--font-size-xl);
 `;
 

--- a/src/components/Comment/CommentForm.tsx
+++ b/src/components/Comment/CommentForm.tsx
@@ -1,4 +1,4 @@
-import React, { Dispatch, SetStateAction } from 'react';
+import React from 'react';
 import { useParams } from 'react-router-dom';
 import { useRecoilValue } from 'recoil';
 import styled from 'styled-components';
@@ -15,13 +15,13 @@ import useCreateComment from '../../hooks/comment/useCreateComment';
 interface CommentFormProps {
   isVote?: boolean;
   isProConDiscussion?: boolean;
-  setComments: Dispatch<SetStateAction<Comment[]>>;
+  handleCreateComment: (comment: Comment) => void;
 }
 
 function CommentForm({
   isVote,
   isProConDiscussion,
-  setComments,
+  handleCreateComment,
 }: CommentFormProps) {
   const { postId } = useParams() as { postId: string };
 
@@ -36,7 +36,7 @@ function CommentForm({
         return;
       }
 
-      setComments((prevComments) => [data, ...prevComments]);
+      handleCreateComment(data);
       reset();
     },
   });

--- a/src/components/Comment/CommentForm.tsx
+++ b/src/components/Comment/CommentForm.tsx
@@ -9,8 +9,8 @@ import useInputs from '../../hooks/useInputs';
 import isLoginSelector from '../../recoil/seletors';
 import { jwtAtom } from '../../recoil/atoms';
 import { Comment } from '../../types';
-import { createComment } from '../../apis/comment';
 import PLACEHOLDER from '../../constants/Placeholder';
+import useCreateComment from '../../hooks/comment/useCreateComment';
 
 interface CommentFormProps {
   isVote?: boolean;
@@ -30,6 +30,17 @@ function CommentForm({
 
   const [{ content }, onChange, reset] = useInputs({ content: '' });
 
+  const { mutate: createComment } = useCreateComment({
+    onSuccess: (data) => {
+      if (!data) {
+        return;
+      }
+
+      setComments((prevComments) => [data, ...prevComments]);
+      reset();
+    },
+  });
+
   const handleSubmit = async (event: React.MouseEvent<HTMLButtonElement>) => {
     event.preventDefault();
 
@@ -37,9 +48,7 @@ function CommentForm({
       return;
     }
 
-    const data = await createComment(postId, token, content);
-    setComments((prevComments) => [data, ...prevComments]);
-    reset();
+    await createComment({ id: Number(postId), content, token });
   };
 
   let disabled = false;

--- a/src/components/Comment/CommentForm.tsx
+++ b/src/components/Comment/CommentForm.tsx
@@ -2,9 +2,9 @@ import React from 'react';
 import { useParams } from 'react-router-dom';
 import { useRecoilValue } from 'recoil';
 import styled from 'styled-components';
-import Input from '../UI/Input/Input';
+import Textarea from '../UI/Textarea/Textarea';
 import { ButtonBox } from '../UI/Button/Button';
-import { rowFlex } from '../../styles/shared';
+import { colFlex } from '../../styles/shared';
 import useInputs from '../../hooks/useInputs';
 import isLoginSelector from '../../recoil/seletors';
 import { jwtAtom } from '../../recoil/atoms';
@@ -82,7 +82,7 @@ function CommentForm({
       />
       <SubmitButton
         type="submit"
-        buttonType="buttonRight"
+        buttonType="button"
         buttonColor="white"
         buttonSize="sm"
         disabled={disabled}
@@ -95,19 +95,19 @@ function CommentForm({
 }
 
 const CommentFormContainer = styled.form`
-  ${rowFlex}
+  ${colFlex}
+  align-items: flex-end;
+  gap: 12px;
   margin: 40px 20px;
 `;
 
-const CommentInput = styled(Input)`
+const CommentInput = styled(Textarea)`
   width: 100%;
-  border-radius: 5px 0 0 5px;
-  border-right: 0;
 `;
 
 const SubmitButton = styled(ButtonBox)`
-  width: 75px;
-  height: 45px;
+  width: 100px;
+  height: 36px;
   color: var(--black);
 
   &:disabled {

--- a/src/components/Comment/CommentItem.tsx
+++ b/src/components/Comment/CommentItem.tsx
@@ -1,4 +1,4 @@
-import { Dispatch, SetStateAction, useState } from 'react';
+import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useRecoilValue } from 'recoil';
 import dayjs from 'dayjs';
@@ -29,13 +29,15 @@ import useDeleteCommentDislike from '../../hooks/comment/useDeleteCommentDislike
 interface CommentItemProps {
   comment: Comment;
   isProConDiscussion?: boolean;
-  setComments: Dispatch<SetStateAction<Comment[]>>;
+  handleUpdateComment: (commentId: number, content: string) => void;
+  handleDeleteComment: (commentId: number) => void;
 }
 
 function CommentItem({
   comment,
   isProConDiscussion = false,
-  setComments,
+  handleUpdateComment,
+  handleDeleteComment,
 }: CommentItemProps) {
   const navigate = useNavigate();
 
@@ -81,22 +83,14 @@ function CommentItem({
         return;
       }
 
-      setComments((prevComments) =>
-        prevComments.map((prevComment) =>
-          prevComment.id === id
-            ? { ...prevComment, content: data.content }
-            : prevComment,
-        ),
-      );
+      handleUpdateComment(id, data.content);
       setIsEdit(false);
     },
   });
 
   const { mutate: deleteComment } = useDeleteComment({
     onSuccess: () => {
-      setComments((prevComments) =>
-        prevComments.filter((prevComment) => prevComment.id !== id),
-      );
+      handleDeleteComment(id);
     },
   });
 

--- a/src/components/Comment/CommentItem.tsx
+++ b/src/components/Comment/CommentItem.tsx
@@ -288,6 +288,8 @@ const Button = styled.button`
 const CommentContent = styled.p`
   line-height: 20px;
   color: var(--color-content-text);
+  white-space: pre-wrap;
+  word-break: break-all;
 `;
 
 const CountText = styled.p`

--- a/src/components/ProConDiscussionDetail/TopicDescription.tsx
+++ b/src/components/ProConDiscussionDetail/TopicDescription.tsx
@@ -1,11 +1,21 @@
 import { useNavigate } from 'react-router-dom';
 import { useRecoilValue } from 'recoil';
 import styled from 'styled-components';
+import UserProfile from '../UI/UserProfile/UserProfile';
 import ButtonBox from '../UI/Button/Button';
-import { buttonActiveCSS, buttonDeactivateCSS } from '../../styles/shared';
+import {
+  buttonActiveCSS,
+  buttonDeactivateCSS,
+  colFlex,
+  discussionContentCSS,
+  rowFlex,
+  rowFlexCenter,
+} from '../../styles/shared';
 import isLoginSelector from '../../recoil/seletors';
 
 interface TopicDescriptionProps {
+  author: string;
+  avatarUrl: string;
   content: string;
   isPro: boolean;
   isVote: boolean;
@@ -14,6 +24,8 @@ interface TopicDescriptionProps {
 }
 
 function TopicDescription({
+  author,
+  avatarUrl,
   content,
   isPro,
   isVote,
@@ -39,7 +51,16 @@ function TopicDescription({
 
   return (
     <DescriptionContainer>
-      <DescriptionText>{content}</DescriptionText>
+      <DescriptionBox>
+        <UserProfile
+          avatar={avatarUrl}
+          alt={`${author} 프로필 이미지`}
+          itemGap="10px"
+          nickname={author}
+          size="sm"
+        />
+        <DescriptionText>{content}</DescriptionText>
+      </DescriptionBox>
       <ButtonContainer>
         <ProConButton
           type="button"
@@ -69,20 +90,22 @@ function TopicDescription({
 }
 
 const DescriptionContainer = styled.section`
-  display: flex;
-  flex-direction: column;
+  ${colFlex}
   gap: 24px;
   margin: 40px 20px;
 `;
 
+const DescriptionBox = styled.div`
+  ${rowFlex}
+  gap: 16px;
+`;
+
 const DescriptionText = styled.p`
-  line-height: 20px;
-  color: var(--color-content-text);
+  ${discussionContentCSS}
 `;
 
 const ButtonContainer = styled.div`
-  display: flex;
-  justify-content: center;
+  ${rowFlexCenter}
 `;
 
 const ProConButton = styled(ButtonBox)<{ isVote: boolean; isActive: boolean }>`

--- a/src/hooks/bookDiscussion/useBookDiscussionDetail.ts
+++ b/src/hooks/bookDiscussion/useBookDiscussionDetail.ts
@@ -2,6 +2,7 @@ import useQuery from '../useQuery';
 import {
   APIError,
   BookDiscussionDetail,
+  Comment,
   GetBookDiscussionDetailType,
 } from '../../types';
 
@@ -22,7 +23,7 @@ function useBookDiscussionDetail({
   isSuspense = false,
   isErrorBoundary = false,
 }: UseBookDiscussionDetailProps) {
-  const { data, isLoading, error } = useQuery<
+  const { data, isLoading, error, setData } = useQuery<
     GetBookDiscussionDetailType,
     BookDiscussionDetail
   >({
@@ -34,7 +35,61 @@ function useBookDiscussionDetail({
     onError,
   });
 
-  return { data, isLoading, error };
+  const handleCreateComment = (comment: Comment) => {
+    setData((prev) => {
+      if (!prev) {
+        return prev;
+      }
+
+      return {
+        ...prev,
+        comments: [comment, ...prev.comments],
+      };
+    });
+  };
+
+  const handleUpdateComment = (commentId: number, content: string) => {
+    setData((prev) => {
+      if (!prev) {
+        return prev;
+      }
+
+      const updatedComments = prev.comments.map((comment) =>
+        comment.id === commentId ? { ...comment, content } : comment,
+      );
+
+      return {
+        ...prev,
+        comments: updatedComments,
+      };
+    });
+  };
+
+  const handleDeleteComment = (commentId: number) => {
+    setData((prev) => {
+      if (!prev) {
+        return prev;
+      }
+
+      const updatedComments = prev.comments.filter(
+        (comment) => comment.id !== commentId,
+      );
+
+      return {
+        ...prev,
+        comments: updatedComments,
+      };
+    });
+  };
+
+  return {
+    data,
+    isLoading,
+    error,
+    handleCreateComment,
+    handleUpdateComment,
+    handleDeleteComment,
+  };
 }
 
 export default useBookDiscussionDetail;

--- a/src/hooks/comment/useCreateComment.ts
+++ b/src/hooks/comment/useCreateComment.ts
@@ -1,0 +1,18 @@
+import { createComment } from '../../apis/comment';
+import { Comment, CommentFormType, UseCommentFormType } from '../../types';
+import useMutate from '../useMutate';
+
+function useCreateComment({ onSuccess, onError }: UseCommentFormType) {
+  const { mutate, data, error, isLoading } = useMutate<
+    CommentFormType,
+    Comment
+  >({
+    fetchFn: createComment,
+    onSuccess,
+    onError,
+  });
+
+  return { mutate, data, error, isLoading };
+}
+
+export default useCreateComment;

--- a/src/hooks/comment/useCreateCommentDislike.ts
+++ b/src/hooks/comment/useCreateCommentDislike.ts
@@ -1,0 +1,15 @@
+import { createCommentDislike } from '../../apis/comment';
+import { CommentType, UseCommentType } from '../../types';
+import useMutate from '../useMutate';
+
+function useCreateCommentDislike({ onSuccess, onError }: UseCommentType) {
+  const { mutate, data, error, isLoading } = useMutate<CommentType, any>({
+    fetchFn: createCommentDislike,
+    onSuccess,
+    onError,
+  });
+
+  return { mutate, data, error, isLoading };
+}
+
+export default useCreateCommentDislike;

--- a/src/hooks/comment/useCreateCommentLike.ts
+++ b/src/hooks/comment/useCreateCommentLike.ts
@@ -1,0 +1,15 @@
+import { createCommentLike } from '../../apis/comment';
+import { CommentType, UseCommentType } from '../../types';
+import useMutate from '../useMutate';
+
+function useCreateCommentLike({ onSuccess, onError }: UseCommentType) {
+  const { mutate, data, error, isLoading } = useMutate<CommentType, any>({
+    fetchFn: createCommentLike,
+    onSuccess,
+    onError,
+  });
+
+  return { mutate, data, error, isLoading };
+}
+
+export default useCreateCommentLike;

--- a/src/hooks/comment/useDeleteComment.ts
+++ b/src/hooks/comment/useDeleteComment.ts
@@ -1,0 +1,15 @@
+import { deleteComment } from '../../apis/comment';
+import { CommentType, UseCommentType } from '../../types';
+import useMutate from '../useMutate';
+
+function useDeleteComment({ onSuccess, onError }: UseCommentType) {
+  const { mutate, data, error, isLoading } = useMutate<CommentType, any>({
+    fetchFn: deleteComment,
+    onSuccess,
+    onError,
+  });
+
+  return { mutate, data, error, isLoading };
+}
+
+export default useDeleteComment;

--- a/src/hooks/comment/useDeleteCommentDislike.ts
+++ b/src/hooks/comment/useDeleteCommentDislike.ts
@@ -1,0 +1,15 @@
+import { deleteCommentDislike } from '../../apis/comment';
+import { CommentType, UseCommentType } from '../../types';
+import useMutate from '../useMutate';
+
+function useDeleteCommentDislike({ onSuccess, onError }: UseCommentType) {
+  const { mutate, data, error, isLoading } = useMutate<CommentType, any>({
+    fetchFn: deleteCommentDislike,
+    onSuccess,
+    onError,
+  });
+
+  return { mutate, data, error, isLoading };
+}
+
+export default useDeleteCommentDislike;

--- a/src/hooks/comment/useDeleteCommentLike.ts
+++ b/src/hooks/comment/useDeleteCommentLike.ts
@@ -1,0 +1,15 @@
+import { deleteCommentLike } from '../../apis/comment';
+import { CommentType, UseCommentType } from '../../types';
+import useMutate from '../useMutate';
+
+function useDeleteCommentLike({ onSuccess, onError }: UseCommentType) {
+  const { mutate, data, error, isLoading } = useMutate<CommentType, any>({
+    fetchFn: deleteCommentLike,
+    onSuccess,
+    onError,
+  });
+
+  return { mutate, data, error, isLoading };
+}
+
+export default useDeleteCommentLike;

--- a/src/hooks/comment/useUpdateComment.ts
+++ b/src/hooks/comment/useUpdateComment.ts
@@ -1,0 +1,18 @@
+import { updateComment } from '../../apis/comment';
+import { Comment, CommentFormType, UseCommentFormType } from '../../types';
+import useMutate from '../useMutate';
+
+function useUpdateComment({ onSuccess, onError }: UseCommentFormType) {
+  const { mutate, data, error, isLoading } = useMutate<
+    CommentFormType,
+    Comment
+  >({
+    fetchFn: updateComment,
+    onSuccess,
+    onError,
+  });
+
+  return { mutate, data, error, isLoading };
+}
+
+export default useUpdateComment;

--- a/src/hooks/proConDiscussion/useProConDiscussionDetail.ts
+++ b/src/hooks/proConDiscussion/useProConDiscussionDetail.ts
@@ -1,6 +1,7 @@
 import useQuery from '../useQuery';
 import {
   APIError,
+  Comment,
   GetProConDiscussionDetailType,
   ProConDiscussion,
 } from '../../types';
@@ -50,7 +51,63 @@ function useProConDiscussionDetail({
     });
   };
 
-  return { data, isLoading, error, handleUpdateIsPro, refetch };
+  const handleCreateComment = (comment: Comment) => {
+    setData((prev) => {
+      if (!prev) {
+        return prev;
+      }
+
+      return {
+        ...prev,
+        comments: [comment, ...prev.comments],
+      };
+    });
+  };
+
+  const handleUpdateComment = (commentId: number, content: string) => {
+    setData((prev) => {
+      if (!prev) {
+        return prev;
+      }
+
+      const updatedComments = prev.comments.map((comment) =>
+        comment.id === commentId ? { ...comment, content } : comment,
+      );
+
+      return {
+        ...prev,
+        comments: updatedComments,
+      };
+    });
+  };
+
+  const handleDeleteComment = (commentId: number) => {
+    setData((prev) => {
+      if (!prev) {
+        return prev;
+      }
+
+      const updatedComments = prev.comments.filter(
+        (comment) => comment.id !== commentId,
+      );
+
+      return {
+        ...prev,
+        comments: updatedComments,
+      };
+    });
+  };
+
+  return {
+    data,
+    isLoading,
+    error,
+    handleUpdateIsPro,
+    handleCreateComment,
+    handleUpdateComment,
+    handleDeleteComment,
+    refetch,
+  };
 }
 
 export default useProConDiscussionDetail;

--- a/src/pages/BookDiscussionDetailPage.tsx
+++ b/src/pages/BookDiscussionDetailPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { useRecoilValue } from 'recoil';
 import { BsChatLeftDots } from 'react-icons/bs';
@@ -32,14 +32,23 @@ function BookDiscussionDetailPage() {
     return <Loading />;
   }
 
-  const { id, author, title, content, createdAt, postLikedByUser, book } =
-    bookDiscussion;
+  const {
+    id,
+    author,
+    avatarUrl,
+    title,
+    content,
+    createdAt,
+    postLikedByUser,
+    book,
+  } = bookDiscussion;
 
   return (
     <MainContainer>
       <DiscussionInformation
         id={id}
         author={author}
+        avatarUrl={avatarUrl}
         title={title}
         content={content}
         createdAt={createdAt}

--- a/src/pages/BookDiscussionDetailPage.tsx
+++ b/src/pages/BookDiscussionDetailPage.tsx
@@ -1,4 +1,3 @@
-import { useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { useRecoilValue } from 'recoil';
 import { BsChatLeftDots } from 'react-icons/bs';
@@ -13,19 +12,19 @@ import CommentList from '../components/Comment/CommentList';
 import CommentItem from '../components/Comment/CommentItem';
 import { jwtAtom } from '../recoil/atoms';
 import useBookDiscussionDetail from '../hooks/bookDiscussion/useBookDiscussionDetail';
-import { Comment } from '../types';
 
 function BookDiscussionDetailPage() {
   const { postId } = useParams() as { postId: string };
   const token = useRecoilValue(jwtAtom) ?? '';
-  const [commentsData, setCommentsData] = useState<Comment[]>([]);
 
-  const { data: bookDiscussion } = useBookDiscussionDetail({
+  const {
+    data: bookDiscussion,
+    handleCreateComment,
+    handleUpdateComment,
+    handleDeleteComment,
+  } = useBookDiscussionDetail({
     id: Number(postId),
     token,
-    onSuccess: (newData) => {
-      setCommentsData(newData?.comments || []);
-    },
   });
 
   if (!bookDiscussion) {
@@ -41,6 +40,7 @@ function BookDiscussionDetailPage() {
     createdAt,
     postLikedByUser,
     book,
+    comments,
   } = bookDiscussion;
 
   return (
@@ -61,13 +61,14 @@ function BookDiscussionDetailPage() {
       <Subtitle>
         댓글 <BsChatLeftDots />
       </Subtitle>
-      <CommentForm setComments={setCommentsData} />
+      <CommentForm handleCreateComment={handleCreateComment} />
       <CommentList>
-        {commentsData.map((comment) => (
+        {comments.map((comment) => (
           <CommentItem
             key={comment.id}
             comment={comment}
-            setComments={setCommentsData}
+            handleUpdateComment={handleUpdateComment}
+            handleDeleteComment={handleDeleteComment}
           />
         ))}
       </CommentList>

--- a/src/pages/ProConDiscussionDetailPage.tsx
+++ b/src/pages/ProConDiscussionDetailPage.tsx
@@ -65,6 +65,7 @@ function ProConDiscussionDetailPage() {
   const {
     id,
     author,
+    avatarUrl,
     title,
     content,
     createdAt,
@@ -92,6 +93,8 @@ function ProConDiscussionDetailPage() {
         주제 설명 <BsInfoCircle />
       </Subtitle>
       <TopicDescription
+        author={author}
+        avatarUrl={avatarUrl}
         content={content}
         isPro={isPro}
         isVote={isVote}

--- a/src/pages/ProConDiscussionDetailPage.tsx
+++ b/src/pages/ProConDiscussionDetailPage.tsx
@@ -1,4 +1,3 @@
-import { useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { useRecoilValue } from 'recoil';
 import { BsChatLeftDots, BsInfoCircle } from 'react-icons/bs';
@@ -10,7 +9,6 @@ import TopicDescription from '../components/ProConDiscussionDetail/TopicDescript
 import CommentForm from '../components/Comment/CommentForm';
 import CommentList from '../components/Comment/CommentList';
 import CommentItem from '../components/Comment/CommentItem';
-import { Comment } from '../types';
 import { jwtAtom } from '../recoil/atoms';
 
 import useProConDiscussionDetail from '../hooks/proConDiscussion/useProConDiscussionDetail';
@@ -20,14 +18,16 @@ import useCreateProConVote from '../hooks/proConVote/useCreateProConVote';
 function ProConDiscussionDetailPage() {
   const { postId } = useParams() as { postId: string };
   const token = useRecoilValue(jwtAtom) ?? '';
-  const [commentsData, setCommentsData] = useState<Comment[]>([]);
 
-  const { data: proConDiscussion, refetch } = useProConDiscussionDetail({
+  const {
+    data: proConDiscussion,
+    handleCreateComment,
+    handleUpdateComment,
+    handleDeleteComment,
+    refetch,
+  } = useProConDiscussionDetail({
     id: Number(postId),
     token,
-    onSuccess: (data) => {
-      setCommentsData(data?.comments || []);
-    },
   });
 
   const { mutate: createProConVote } = useCreateProConVote({
@@ -75,6 +75,7 @@ function ProConDiscussionDetailPage() {
     conLeader,
     isVote,
     isPro,
+    comments,
   } = proConDiscussion;
 
   return (
@@ -107,15 +108,16 @@ function ProConDiscussionDetailPage() {
       <CommentForm
         isVote={isVote}
         isProConDiscussion
-        setComments={setCommentsData}
+        handleCreateComment={handleCreateComment}
       />
       <CommentList>
-        {commentsData.map((comment) => (
+        {comments.map((comment) => (
           <CommentItem
             key={comment.id}
             comment={comment}
             isProConDiscussion
-            setComments={setCommentsData}
+            handleUpdateComment={handleUpdateComment}
+            handleDeleteComment={handleDeleteComment}
           />
         ))}
       </CommentList>

--- a/src/styles/shared.tsx
+++ b/src/styles/shared.tsx
@@ -110,3 +110,14 @@ export const buttonActiveCSS = css`
 export const buttonDeactivateCSS = css`
   filter: brightness(75%);
 `;
+
+export const discussionContentCSS = css`
+  width: 100%;
+  padding: 16px;
+  border-radius: 8px;
+  color: var(--color-content-text);
+  background-color: var(--color-inputbox-bg);
+  line-height: 20px;
+  white-space: pre-wrap;
+  word-break: break-all;
+`;

--- a/src/types/Comment.type.ts
+++ b/src/types/Comment.type.ts
@@ -1,12 +1,34 @@
+import { APIError } from './index';
+
 export interface Comment {
   id: number;
   author: string;
+  avatarUrl: string;
   content: string;
   like: number;
   dislike: number;
   createdAt: string;
   updatedAt: string;
-  likedByUser: boolean;
-  dislikedByUser: boolean;
+  likedByUser?: boolean;
+  dislikedByUser?: boolean;
   isPro?: boolean;
+}
+
+export interface CommentType {
+  id: number;
+  token: string;
+}
+
+export interface CommentFormType extends CommentType {
+  content: string;
+}
+
+export interface UseCommentType {
+  onSuccess?: () => void;
+  onError?: (error: Error | APIError) => void;
+}
+
+export interface UseCommentFormType {
+  onSuccess?: (data: Comment | null) => void;
+  onError?: (error: Error | APIError) => void;
 }


### PR DESCRIPTION
### 📌 관련 이슈
- #97 
- #119 

### ✨개발 내용
- 독서/찬반토론(상세) 댓글 커스텀 훅 적용
- 찬반토론 저자 정보 추가 / 댓글 입력 폼 변경

### 📸 스크린샷
- 찬반토론을 작성한 저자 정보를 주제 설명에 추가했습니다.
- 댓글 입력 폼을 Input에서 Textarea로 변경하면서 CSS를 수정했습니다.
<img width="1140" alt="detail" src="https://github.com/jumak-dev/imojumo/assets/75026933/a841efb0-8e93-4e97-8dde-6f6e22a4af0a">