### PR TITLE
[Feature] Pagination 페이지 버튼 개수 고정

### DIFF
--- a/src/components/UI/Pagination/Pagination.tsx
+++ b/src/components/UI/Pagination/Pagination.tsx
@@ -1,18 +1,23 @@
-import React from 'react';
 import styled from 'styled-components';
 import { IoIosArrowBack, IoIosArrowForward } from 'react-icons/io';
 import { RxDoubleArrowLeft, RxDoubleArrowRight } from 'react-icons/rx';
 import { PaginationType } from '../../../types';
 import { flex } from '../../../styles/shared';
+import getPageIndex from '../../../utils/pageIndex';
 
 function Pagination({
   currentPage,
   setPaginate,
   pageInfo,
+  pageLimit,
   className,
 }: PaginationType) {
   const { page, totalPage } = pageInfo || { page: 1, totalPage: 1 };
-  const pageNumbers = Array.from({ length: totalPage }, (_, idx) => idx + 1);
+  const { startPage, endPage } = getPageIndex(page, totalPage, pageLimit);
+  const pageNumbers = Array.from(
+    { length: endPage - startPage + 1 },
+    (_, idx) => startPage + idx,
+  );
 
   const handleClick = (num: number) => {
     setPaginate(num);

--- a/src/types/Page.type.ts
+++ b/src/types/Page.type.ts
@@ -11,5 +11,6 @@ export interface PaginationType {
   pageInfo: PageInfo | undefined;
   currentPage: number;
   setPaginate: React.Dispatch<React.SetStateAction<number>>;
+  pageLimit?: number;
   className?: string;
 }

--- a/src/utils/pageIndex.ts
+++ b/src/utils/pageIndex.ts
@@ -1,0 +1,12 @@
+const getPageIndex = (
+  pageNumber: number,
+  totalPage: number,
+  pageLimit: number = 5,
+) => {
+  const pageIndex = Math.floor((pageNumber - 1) / pageLimit);
+  const startPage = pageIndex * pageLimit + 1;
+  const endPage = Math.min(startPage + pageLimit - 1, totalPage);
+  return { startPage, endPage };
+};
+
+export default getPageIndex;


### PR DESCRIPTION
### 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요. -->
- #7

### ✨개발 내용
<!-- 개발한 내용을 설명을 적어주세요 -->
- pagination 페이지 버튼 개수 고정

> 게시물의 양이 방대해져 총 페이지 수가 많아졌을 때 페이지 수가 많든 적든 고정으로 1-5 6-10 11-15 와 같이 고정적인 `pageLimit` 값을 받아 `pageLimit`만큼의 페이지 버튼을 생성하게 수정하였습니다! `Pagination` 컴포넌트를 사용할 때 작은 UI 내부라면 pageLimit 값을 할당하여 원하는 개수만큼 조절해서 사용할 수 있습니다. `pageLimit` 값은 **선택**입니다. 기본값은 5로 설정해 두었습니다.

### src/utils/pageIndex.ts
```ts
const getPageIndex = (
  pageNumber: number,
  totalPage: number,
  pageLimit: number = 5,
) => {
  const pageIndex = Math.floor((pageNumber - 1) / pageLimit);
  const startPage = pageIndex * pageLimit + 1;
  const endPage = Math.min(startPage + pageLimit - 1, totalPage);
  return { startPage, endPage };
};

export default getPageIndex;
```